### PR TITLE
Handling nulls

### DIFF
--- a/Simple.Data.Ado/CommandBuilder.cs
+++ b/Simple.Data.Ado/CommandBuilder.cs
@@ -151,8 +151,13 @@ namespace Simple.Data.Ado
             var parameter = command.CreateParameter();
             parameter.ParameterName = name;
             parameter.DbType = dbType;
-            parameter.Value = value;
+            parameter.Value = GetTheDataParameterValue(value);
             return parameter;
+        }
+
+        private static object GetTheDataParameterValue(object value)
+        {
+            return value ?? DBNull.Value;
         }
     }
 }

--- a/Simple.Data.BehaviourTest/DatabaseTest.cs
+++ b/Simple.Data.BehaviourTest/DatabaseTest.cs
@@ -251,6 +251,16 @@ namespace Simple.Data.IntegrationTest
         }
 
         [Test]
+        public void TestThatUpdateUsesDbNullForNullValues()
+        {
+            var mockDatabase = new MockDatabase();
+            dynamic database = CreateDatabase(mockDatabase);
+            database.Users.UpdateById(Id: 1, Name: null);
+            Assert.AreEqual("update [dbo].[Users] set [Name] = @p1 where [dbo].[Users].[Id] = @p2".ToLowerInvariant(), mockDatabase.Sql.ToLowerInvariant());
+            Assert.AreEqual(DBNull.Value, mockDatabase.Parameters[0]);
+        }
+
+        [Test]
         public void TestDeleteWithNamedArguments()
         {
             var mockDatabase = new MockDatabase();


### PR DESCRIPTION
Hi Mark,

I've started using the SQL Server adapter for Simple.Data, and I noticed that it seemed impossible to set nullable fields to NULL through an update statement.  I took a look in the code, and I think it's due to the way nulls are set on the parameters for the database command.  

If the value on the parameter is set to null, SQL Server will set the parameter value to "default" in the SQL statement that it generates.  However, since those nullable columns don't have default values, SQL Server seems to treat the "default" as a missing value and will fail the entire update statement.

My update was to set the parameter value to DBNull.Value when it is null, and that appears to correct the issue for me (running SQL Server 2008).  

I don't know how this affects the other adapters, but I think this type of update might be necessary for handling the issue for SQL Server.

Anyway, hope it helps!

Darren
