### PR TITLE
Parameters to call a function are not created correctly

### DIFF
--- a/Simple.Data.SqlTest/ProcedureTest.cs
+++ b/Simple.Data.SqlTest/ProcedureTest.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
+﻿using System.Diagnostics;
 using NUnit.Framework;
 
 namespace Simple.Data.SqlTest
@@ -67,6 +63,14 @@ namespace Simple.Data.SqlTest
             var order = results.FirstOrDefault();
             Assert.IsNotNull(order);
             Assert.AreEqual(1, order.OrderId);
+        }
+
+        [Test]
+        public void ScalarFunctionIsCalledCorrectly()
+        {
+            var db = DatabaseHelper.Open();
+            var results = db.VarcharAndReturnInt("The answer to everything");
+            Assert.AreEqual(42, results.ReturnValue);
         }
     }
 }

--- a/Simple.Data.SqlTest/Resources/DatabaseReset.txt
+++ b/Simple.Data.SqlTest/Resources/DatabaseReset.txt
@@ -6,6 +6,8 @@ IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[GetCu
 DROP PROCEDURE [dbo].[GetCustomerAndOrders]
 IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[GetCustomerCount]') AND type in (N'P', N'PC'))
 DROP PROCEDURE [dbo].[GetCustomerCount]
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[VarcharAndReturnInt]'))
+DROP FUNCTION [dbo].[VarcharAndReturnInt]
 GO
 
 CREATE PROCEDURE TestReset 
@@ -136,4 +138,12 @@ AS
 BEGIN
     SET NOCOUNT ON;
     RETURN 1
+END
+GO
+CREATE FUNCTION [dbo].[VarcharAndReturnInt] (@AValue varchar(50)) RETURNS INT AS BEGIN
+  IF ISNUMERIC(@AValue) = 1
+  BEGIN
+    RETURN cast (@AValue  as int)
+  END
+  RETURN 42
 END


### PR DESCRIPTION
Hi Mark,
Schema provision in Sqlserver appears flawed since e.g. return values are not listed as parameters. The strategy implemented here uses a CommandBuilder which allows a more accurate description of a procedure/function. Some related changes happen in the procedure executor to cater for the more detailed parameter info.
