### PR TITLE
Test that insert uses db null when inserted a null value.

### DIFF
--- a/Simple.Data.Ado/CommandHelper.cs
+++ b/Simple.Data.Ado/CommandHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -42,7 +43,7 @@ namespace Simple.Data.Ado
                 {
                     var parameter = command.CreateParameter();
                     parameter.ParameterName = _schemaProvider.NameParameter("p" + index);
-                    parameter.Value = values[index];
+                    parameter.Value = values[index] ?? DBNull.Value;
                     command.Parameters.Add(parameter);
                     
                     sqlBuilder.Append(parameter.ParameterName);

--- a/Simple.Data.BehaviourTest/DatabaseTest.cs
+++ b/Simple.Data.BehaviourTest/DatabaseTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Dynamic;
+﻿using System;
+using System.Dynamic;
 using NUnit.Framework;
 using Simple.Data.Mocking.Ado;
 
@@ -282,6 +283,15 @@ namespace Simple.Data.IntegrationTest
             GeneratedSqlIs("insert into [dbo].[Users] ([Name],[Age]) values (@p0,@p1)");
             Parameter(0).Is("Phil");
             Parameter(1).Is(42);
+        }
+
+        [Test]
+        public void TestThatInsertUsesDBNull()
+        {
+            dynamic person = new ExpandoObject();
+            person.Name = null;
+            _db.Users.Insert(person);
+            Parameter(0).Is(DBNull.Value);
         }
     }
 }


### PR DESCRIPTION
I found another place where DBNull.Value was not being used when setting the parameter value.  If the parameter value is set to null instead of DBNull.Value, an invalid SQL statement will be generated by the SQL command.

I see two other places where it might be good to put a:  value ?? DBNull.Value , which seem to be used when setting criteria for finding and deleting records.  I couldn't write a good test case for these situations, though, because it seems that the nulls are handled (or an in-code exception is thrown) before the null parameters are built. 
