### PR TITLE
Add more basic operations to simple query

### DIFF
--- a/Simple.Data.UnitTest/SimpleQueryTest.cs
+++ b/Simple.Data.UnitTest/SimpleQueryTest.cs
@@ -129,7 +129,23 @@ namespace Simple.Data.UnitTest
             try
             {
                 var query = new SimpleQuery(null, "foo") as dynamic;
-                (query as dynamic).Count().ShouldEqual(0);
+                (query as dynamic).Count();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            Assert.IsNotInstanceOf(typeof(RuntimeBinderException), exception);
+        }
+
+        [Test]
+        public void RespondsToAnyAsDynamic()
+        {
+            Exception exception = null;
+            try
+            {
+                var query = new SimpleQuery(null, "foo") as dynamic;
+                (query as dynamic).Any();
             }
             catch (Exception ex)
             {

--- a/Simple.Data.UnitTest/SimpleQueryTest.cs
+++ b/Simple.Data.UnitTest/SimpleQueryTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Microsoft.CSharp.RuntimeBinder;
 using NUnit.Framework;
 
 namespace Simple.Data.UnitTest
@@ -119,6 +120,22 @@ namespace Simple.Data.UnitTest
         public void ThenByDescendingWithoutOrderByShouldThrow()
         {
             new SimpleQuery(null, "foo").ThenByDescending(new DynamicReference("bar"));
+        }
+
+        [Test]
+        public void RespondsToCountAsADynamic()
+        {
+            Exception exception = null;
+            try
+            {
+                var query = new SimpleQuery(null, "foo") as dynamic;
+                (query as dynamic).Count().ShouldEqual(0);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+            Assert.IsNotInstanceOf(typeof(RuntimeBinderException), exception);
         }
     }
 }

--- a/Simple.Data/SimpleQuery.cs
+++ b/Simple.Data/SimpleQuery.cs
@@ -284,5 +284,10 @@ namespace Simple.Data
         {
             return Records.Count();
         }
+
+        public bool Any()
+        {
+            return Records.Any();
+        }
     }
 }

--- a/Simple.Data/SimpleQuery.cs
+++ b/Simple.Data/SimpleQuery.cs
@@ -279,5 +279,10 @@ namespace Simple.Data
         {
             return Cast<T>().SingleOrDefault(predicate);
         }
+
+        public int Count()
+        {
+            return Records.Count();
+        }
     }
 }


### PR DESCRIPTION
I added Count() and Any() to Simple Query, which allows them to be used when handling the simple query as a dynamic.  

The tests aren't great -- I wasn't sure of another way to unit test these updates, so my tests are what happened to me while trying to use Simple.Data in my own integration tests.  I just assert that I don't get the binding exception when I call them methods.
