### PR TITLE
Prevent FindBy from executing query twice

### DIFF
--- a/Simple.Data.SqlTest/Resources/DatabaseReset.txt
+++ b/Simple.Data.SqlTest/Resources/DatabaseReset.txt
@@ -126,7 +126,8 @@ BEGIN
 	INSERT INTO [dbo].[Users] ([Id], [Name], [Password], [Age]) VALUES (3,'Dave','Dave',12)
 	SET IDENTITY_INSERT [dbo].[Users] OFF
 	
-	DECLARE @PagingId AS INT = 1
+	DECLARE @PagingId AS INT
+	SET @PagingId = 1
 	WHILE @PagingId <= 100
 	BEGIN
 		INSERT INTO [dbo].[PagingTest] ([Id]) VALUES (@PagingId)

--- a/Simple.Data/Commands/FindByCommand.cs
+++ b/Simple.Data/Commands/FindByCommand.cs
@@ -33,7 +33,7 @@ namespace Simple.Data.Commands
                            {
                                var data = func(a);
                                return (data != null && data.Count > 0)
-                                          ? new SimpleRecord(func(a), table.GetQualifiedName(), dataStrategy)
+                                          ? new SimpleRecord(data, table.GetQualifiedName(), dataStrategy)
                                           : null;
                            };
             }


### PR DESCRIPTION
Hi! I've noticed that query generated by FindBy method is executed twice on database.

This should fix it.
