### PR TITLE
Fixed bug in CreateParameters

### DIFF
--- a/Simple.Data.Ado/CommandTemplate.cs
+++ b/Simple.Data.Ado/CommandTemplate.cs
@@ -43,6 +43,7 @@ namespace Simple.Data.Ado
         {
             var fixedParameters = _parameters.Where(pt => pt.Type == ParameterType.FixedValue).ToArray();
             if ((!parameterValues.Any(pv => pv != null)) && fixedParameters.Length == 0) yield break;
+            parameterValues = parameterValues.Where(pv => pv != null);
 
             foreach (var fixedParameter in fixedParameters)
             {

--- a/Simple.Data.BehaviourTest/DatabaseIntegrationContext.cs
+++ b/Simple.Data.BehaviourTest/DatabaseIntegrationContext.cs
@@ -37,6 +37,9 @@ namespace Simple.Data.IntegrationTest
             dynamic obj = new ExpandoObject();
             obj.Is = new Action<object>(v => Assert.AreEqual(v, _mockDatabase.Parameters[index]));
             obj.IsDBNull = new Action(() => Assert.AreEqual(DBNull.Value, _mockDatabase.Parameters[index]));
+            obj.Exists = new Action(()=> Assert.DoesNotThrow(() => _mockDatabase.Parameters[index].ToString()));
+            obj.DoesNotExist = new Action(
+                    () => Assert.Throws<IndexOutOfRangeException>(() => _mockDatabase.Parameters[index].ToString()));
             return obj;
         }
 

--- a/Simple.Data.BehaviourTest/FindTest.cs
+++ b/Simple.Data.BehaviourTest/FindTest.cs
@@ -32,6 +32,15 @@ namespace Simple.Data.IntegrationTest
         }
 
         [Test]
+        public void TestFindWithTwoCriteriasOneBeingNull()
+        {
+            _db.Users.Find(_db.Users.Id == 1 || _db.Users.Id == null);
+            GeneratedSqlIs("select [dbo].[users].* from [dbo].[users] where ([dbo].[users].[id] = @p1 OR [dbo].[users].[id] IS NULL)");
+            Parameter(0).Is(1);
+            Parameter(1).DoesNotExist();
+        }
+
+        [Test]
         public void TestFindNotEqualWithInt32()
         {
             _db.Users.Find(_db.Users.Id != 1);


### PR DESCRIPTION
In the CreateParameters method of the CommandTemplate class if null was the only parameter given, no parameters was created, as "= @p1" is replaced with IS NULL in the sql.
However when more than one value was given in the parameters there was no removing of null values, and an index out of range exception was thrown because the number of parameters was larger than the number of parameter placeholders in the sql ("= @p"1 was still replaced with IS NULL)
