### PR TITLE
Stored procedure execution: set the command parameter's direction

### DIFF
--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -107,7 +107,8 @@ namespace Simple.Data.Ado
                 {
                     suppliedParameters.TryGetValue("_" + i, out value);
                 }
-                cmd.AddParameter(parameter.Name, value);
+                var cmdParameter = cmd.AddParameter(parameter.Name, value);
+                cmdParameter.Direction = parameter.Direction;
                 i++;
             }
         }


### PR DESCRIPTION
This patch sets the 'Direction' property of each IDbDataParameter parameter based on the directional values defined by a stored procedure's schema.

I had to do this so that OUTPUT parameter values would actually have a value set after executing a stored procedure (otherwise value was zero).
