### PR TITLE
Link to wiki home page works better

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you'd like to create an adapter or provider and need some help to get started
 
 ## Resources
 * Simple.Data can be installed from [NuGet](http://nuget.org/)
-* Find more information in [the wiki](http://github.com/markrendle/Simple.Data/wiki/Getting-started)
+* Find more information in [the wiki](https://github.com/markrendle/Simple.Data/wiki)
 * [Documentation!](http://simplefx.org/simpledata/docs/)
 * Ask questions or report issues on [the mailing list](http://groups.google.com/group/simpledata)
 * Follow [@markrendle on Twitter](http://twitter.com/markrendle) for updates


### PR DESCRIPTION
The Getting Started page doesn't have any links to other content, leaving you a bit lost - wiki home page is better.
