### PR TITLE
Ignore case when resolving stored procedure parameter names

### DIFF
--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -96,6 +96,8 @@ namespace Simple.Data.Ado
 
         private static void SetParameters(Procedure procedure, IDbCommand cmd, IDictionary<string, object> suppliedParameters)
         {
+            suppliedParameters = suppliedParameters.ToDictionary(k => k.Key, e => e.Value, StringComparer.OrdinalIgnoreCase);
+
             if (procedure.Parameters.Any(p=>p.Direction == ParameterDirection.ReturnValue))
               AddReturnParameter(cmd);
 


### PR DESCRIPTION
This patch makes matching supplied parameter names with a procedure's parameter names case insensitive.  

This has been tested against SQL Server and near as I can tell, based on documentation only, should also work for Oracle, MySQL, and PostgreSQL.

An alternative approach would be to build a case-insensitive dictionary in DataStrategy.TryInvokeMember() and DynamicSchema.TryInvokeMember().  This way the dictionary doesn't have to be rebuilt at a later point.  Open to suggetions  : )
