### PR TITLE
Fix for issue 91

### DIFF
--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -7,75 +7,60 @@ using System.Linq;
 using Simple.Data.Ado.Schema;
 using ResultSet = System.Collections.Generic.IEnumerable<System.Collections.Generic.IDictionary<string, object>>;
 
-namespace Simple.Data.Ado
-{
-    public interface IProcedureExecutor
-    {
+namespace Simple.Data.Ado {
+    public interface IProcedureExecutor {
         IEnumerable<ResultSet> Execute(IDictionary<string, object> suppliedParameters);
         IEnumerable<ResultSet> ExecuteReader(IDbCommand command);
     }
 
-    public class ProcedureExecutor : IProcedureExecutor
-    {
+    public class ProcedureExecutor : IProcedureExecutor {
         private const string SimpleReturnParameterName = "@__Simple_ReturnValue";
 
         private readonly AdoAdapter _adapter;
         private readonly ObjectName _procedureName;
         private Func<IDbCommand, IEnumerable<ResultSet>> _executeImpl;
 
-        public ProcedureExecutor(AdoAdapter adapter, ObjectName procedureName)
-        {
+        public ProcedureExecutor(AdoAdapter adapter, ObjectName procedureName) {
             _adapter = adapter;
             _procedureName = procedureName;
             _executeImpl = ExecuteReader;
         }
 
-        public IEnumerable<ResultSet> Execute(IDictionary<string, object> suppliedParameters)
-        {
+        public IEnumerable<ResultSet> Execute(IDictionary<string, object> suppliedParameters) {
             var procedure = _adapter.GetSchema().FindProcedure(_procedureName);
-            if (procedure == null)
-            {
+            if (procedure == null) {
                 throw new UnresolvableObjectException(_procedureName.ToString());
             }
 
             using (var cn = _adapter.CreateConnection())
-            using (var command = cn.CreateCommand())
-            {
+            using (var command = cn.CreateCommand()) {
                 command.CommandText = procedure.QualifiedName;
                 command.CommandType = CommandType.StoredProcedure;
                 SetParameters(procedure, command, suppliedParameters);
-                try
-                {
+                try {
                     var result = _executeImpl(command);
                     if (command.Parameters.Contains(SimpleReturnParameterName))
-                      suppliedParameters["__ReturnValue"] = command.Parameters.GetValue(SimpleReturnParameterName);
+                        suppliedParameters["__ReturnValue"] = command.Parameters.GetValue(SimpleReturnParameterName);
                     RetrieveOutputParameterValues(procedure, command, suppliedParameters);
                     return result;
-                }
-                catch (DbException ex)
-                {
+                } catch (DbException ex) {
                     throw new AdoAdapterException(ex.Message, command);
                 }
             }
         }
 
-        private static void RetrieveOutputParameterValues(Procedure procedure, IDbCommand command, IDictionary<string, object> suppliedParameters)
-        {
-            foreach (var outputParameter in procedure.Parameters.Where(p => p.Direction == ParameterDirection.InputOutput || p.Direction == ParameterDirection.Output))
-            {
+        private static void RetrieveOutputParameterValues(Procedure procedure, IDbCommand command, IDictionary<string, object> suppliedParameters) {
+            foreach (var outputParameter in procedure.Parameters.Where(p => p.Direction == ParameterDirection.InputOutput || p.Direction == ParameterDirection.Output)) {
                 suppliedParameters[outputParameter.Name.Replace("@", "")] =
                     command.Parameters.GetValue(outputParameter.Name);
             }
         }
 
-        public IEnumerable<ResultSet> ExecuteReader(IDbCommand command)
-        {
+        public IEnumerable<ResultSet> ExecuteReader(IDbCommand command) {
             command.WriteTrace();
             command.Connection.Open();
-            using (var reader = command.ExecuteReader())
-            {
-                if (reader.FieldCount > 0)
-                {
+            using (var reader = command.ExecuteReader()) {
+                if (reader.FieldCount > 0) {
                     return reader.ToMultipleDictionaries();
                 }
 
@@ -85,8 +70,7 @@ namespace Simple.Data.Ado
             }
         }
 
-        private static IEnumerable<ResultSet> ExecuteNonQuery(IDbCommand command)
-        {
+        private static IEnumerable<ResultSet> ExecuteNonQuery(IDbCommand command) {
             command.WriteTrace();
             Trace.TraceInformation("ExecuteNonQuery", "Simple.Data.SqlTest");
             command.Connection.Open();
@@ -94,31 +78,33 @@ namespace Simple.Data.Ado
             return Enumerable.Empty<ResultSet>();
         }
 
-        private static void SetParameters(Procedure procedure, IDbCommand cmd, IDictionary<string, object> suppliedParameters)
-        {
-            if (procedure.Parameters.Any(p=>p.Direction == ParameterDirection.ReturnValue))
-              AddReturnParameter(cmd);
+        private static void SetParameters(Procedure procedure, IDbCommand cmd, IDictionary<string, object> suppliedParameters) {
+            if (procedure.Parameters.Any(p => p.Direction == ParameterDirection.ReturnValue))
+                AddReturnParameter(cmd);
 
             int i = 0;
-            foreach (var parameter in procedure.Parameters.Where(p=>p.Direction != ParameterDirection.ReturnValue))
-            {
+            foreach (var parameter in procedure.Parameters.Where(p => p.Direction != ParameterDirection.ReturnValue)) {
                 object value;
-                if (!suppliedParameters.TryGetValue(parameter.Name.Replace("@", ""), out value))
-                {
+                if (!suppliedParameters.TryGetValue(parameter.Name.Replace("@", ""), out value)) {
                     suppliedParameters.TryGetValue("_" + i, out value);
                 }
+    
                 var cmdParameter = cmd.AddParameter(parameter.Name, value);
                 cmdParameter.Direction = parameter.Direction;
+                //Tim Cartwright: I added size and dbtype so inout/out params would function properly.
+                //not setting the proper dbtype and size with out put parameters causes the exception: "Size property has an invalid size of 0"
+                cmdParameter.DbType = parameter.Dbtype; 
+                cmdParameter.Size = parameter.Size;  
                 i++;
             }
         }
 
-        private static void AddReturnParameter(IDbCommand cmd)
-        {
+        private static void AddReturnParameter(IDbCommand cmd) {
             var returnParameter = cmd.CreateParameter();
             returnParameter.ParameterName = SimpleReturnParameterName;
             returnParameter.Direction = ParameterDirection.ReturnValue;
             cmd.Parameters.Add(returnParameter);
         }
+
     }
 }

--- a/Simple.Data.Ado/Schema/Parameter.cs
+++ b/Simple.Data.Ado/Schema/Parameter.cs
@@ -11,12 +11,20 @@ namespace Simple.Data.Ado.Schema
         private readonly string _name;
         private readonly Type _type;
         private readonly ParameterDirection _direction;
+        private int _size;
+        private DbType _dbtype;
 
         public Parameter(string name, Type type, ParameterDirection direction)
         {
             _name = name;
             _direction = direction;
             _type = type;
+        }
+
+        public Parameter(string name, Type type, ParameterDirection direction, DbType dbtype, int size)
+            : this(name, type, direction) {
+            _dbtype = dbtype;
+            _size = size;
         }
 
         public ParameterDirection Direction
@@ -33,5 +41,14 @@ namespace Simple.Data.Ado.Schema
         {
             get { return _name; }
         }
+        //Tim Cartwright: I added size and dbtype so inout/out params would function properly.
+        public int Size {
+            get { return _size; }
+        }
+
+        public DbType Dbtype {
+            get { return _dbtype; }
+        }
+
     }
 }

--- a/Simple.Data.SqlServer/SqlSchemaProvider.cs
+++ b/Simple.Data.SqlServer/SqlSchemaProvider.cs
@@ -81,8 +81,9 @@ namespace Simple.Data.SqlServer
                     connection.Open();
                     SqlCommandBuilder.DeriveParameters(command);
 
+                    //Tim Cartwright: I added size and dbtype so inout/out params would function properly.
                     foreach (SqlParameter p in command.Parameters)
-                        yield return new Parameter(p.ParameterName, SqlTypeResolver.GetClrType(p.DbType.ToString()), p.Direction);
+                        yield return new Parameter(p.ParameterName, SqlTypeResolver.GetClrType(p.DbType.ToString()), p.Direction, p.DbType, p.Size);
                 }
             }
         }


### PR DESCRIPTION
Fixed a bug with using stored procedures that have output parameters with default values. When sending in null or DBNull.Value you get:

Exception "the Size property has an invalid size of 0."

I also by habit reformatted your curly braces. Tried to undo and recommit, but kept getting errors. Sorry. There are less changes than what git is actually reporting however.
