### PR TITLE
Fixed issue where cmd.AddParameter(parameter.Name, value) did not use the "default" keyword

### DIFF
--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -106,7 +106,7 @@ namespace Simple.Data.Ado
                 //Tim Cartwright: Allows for case insensive parameters
                 var value = suppliedParameters.FirstOrDefault(sp => 
                     sp.Key.Equals(parameter.Name.Replace("@", ""), StringComparison.InvariantCultureIgnoreCase)
-                    || sp.Key.Equals("_" + i++)
+                    || sp.Key.Equals("_" + i)
                 );
                 var cmdParameter = cmd.CreateParameter();
                 //Tim Cartwright: Using AddParameter does not allow for the "default" keyword to ever be passed into 
@@ -121,6 +121,7 @@ namespace Simple.Data.Ado
                 cmdParameter.DbType = parameter.Dbtype;
                 cmdParameter.Size = parameter.Size;
                 cmd.Parameters.Add(cmdParameter);
+                i++;
             }
         }
 

--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -48,7 +48,7 @@ namespace Simple.Data.Ado
                 {
                     var result = _executeImpl(command);
                     if (command.Parameters.Contains(SimpleReturnParameterName))
-                      suppliedParameters["__ReturnValue"] = command.Parameters.GetValue(SimpleReturnParameterName);
+                        suppliedParameters["__ReturnValue"] = command.Parameters.GetValue(SimpleReturnParameterName);
                     RetrieveOutputParameterValues(procedure, command, suppliedParameters);
                     return result;
                 }
@@ -96,19 +96,24 @@ namespace Simple.Data.Ado
 
         private static void SetParameters(Procedure procedure, IDbCommand cmd, IDictionary<string, object> suppliedParameters)
         {
-            if (procedure.Parameters.Any(p=>p.Direction == ParameterDirection.ReturnValue))
-              AddReturnParameter(cmd);
+            if (procedure.Parameters.Any(p => p.Direction == ParameterDirection.ReturnValue))
+                AddReturnParameter(cmd);
 
             int i = 0;
-            foreach (var parameter in procedure.Parameters.Where(p=>p.Direction != ParameterDirection.ReturnValue))
+            foreach (var parameter in procedure.Parameters.Where(p => p.Direction != ParameterDirection.ReturnValue))
             {
                 object value;
                 if (!suppliedParameters.TryGetValue(parameter.Name.Replace("@", ""), out value))
                 {
                     suppliedParameters.TryGetValue("_" + i, out value);
                 }
+
                 var cmdParameter = cmd.AddParameter(parameter.Name, value);
                 cmdParameter.Direction = parameter.Direction;
+                //Tim Cartwright: I added size and dbtype so inout/out params would function properly.
+                //not setting the proper dbtype and size with out put parameters causes the exception: "Size property has an invalid size of 0"
+                cmdParameter.DbType = parameter.Dbtype;
+                cmdParameter.Size = parameter.Size;
                 i++;
             }
         }
@@ -120,5 +125,6 @@ namespace Simple.Data.Ado
             returnParameter.Direction = ParameterDirection.ReturnValue;
             cmd.Parameters.Add(returnParameter);
         }
+
     }
 }

--- a/Simple.Data.Ado/Schema/Parameter.cs
+++ b/Simple.Data.Ado/Schema/Parameter.cs
@@ -11,12 +11,21 @@ namespace Simple.Data.Ado.Schema
         private readonly string _name;
         private readonly Type _type;
         private readonly ParameterDirection _direction;
+        private int _size;
+        private DbType _dbtype;
 
         public Parameter(string name, Type type, ParameterDirection direction)
         {
             _name = name;
             _direction = direction;
             _type = type;
+        }
+
+        public Parameter(string name, Type type, ParameterDirection direction, DbType dbtype, int size)
+            : this(name, type, direction)
+        {
+            _dbtype = dbtype;
+            _size = size;
         }
 
         public ParameterDirection Direction
@@ -33,5 +42,16 @@ namespace Simple.Data.Ado.Schema
         {
             get { return _name; }
         }
+        //Tim Cartwright: I added size and dbtype so inout/out params would function properly.
+        public int Size
+        {
+            get { return _size; }
+        }
+
+        public DbType Dbtype
+        {
+            get { return _dbtype; }
+        }
+
     }
 }

--- a/Simple.Data.SqlServer/SqlSchemaProvider.cs
+++ b/Simple.Data.SqlServer/SqlSchemaProvider.cs
@@ -81,8 +81,9 @@ namespace Simple.Data.SqlServer
                     connection.Open();
                     SqlCommandBuilder.DeriveParameters(command);
 
+                    //Tim Cartwright: I added size and dbtype so inout/out params would function properly.
                     foreach (SqlParameter p in command.Parameters)
-                        yield return new Parameter(p.ParameterName, SqlTypeResolver.GetClrType(p.DbType.ToString()), p.Direction);
+                        yield return new Parameter(p.ParameterName, SqlTypeResolver.GetClrType(p.DbType.ToString()), p.Direction, p.DbType, p.Size);
                 }
             }
         }


### PR DESCRIPTION
Mark fixed another issue. Sorry I did not include this yesterday, just noticed it this morning.
