### PR TITLE
Path formatting bug in MefHelper.

### DIFF
--- a/Simple.Data/MefHelper.cs
+++ b/Simple.Data/MefHelper.cs
@@ -44,7 +44,7 @@ namespace Simple.Data
 
         private static CompositionContainer CreateContainer()
         {
-            var path = Assembly.GetExecutingAssembly().CodeBase.Replace("file:///", "");
+            var path = Assembly.GetExecutingAssembly().CodeBase.Replace("file:///", "").Replace("file://","//");
             path = Path.GetDirectoryName(path);
             if (path == null) throw new ArgumentException("Unrecognised file.");
 


### PR DESCRIPTION
I found a small path format issue that manifests when running the library from a network directory. Most people probably won't have this issue but I thought I'd pass it along just the same. 
