### PR TITLE
Changed the BinderHelper to detect IDictionary inputs

### DIFF
--- a/Simple.Data.UnitTest/BinderHelperTest.cs
+++ b/Simple.Data.UnitTest/BinderHelperTest.cs
@@ -26,6 +26,15 @@ namespace Simple.Data.UnitTest
             var actual = binder.ArgumentsToDictionary(new object[] { 1, 2 });
             Assert.AreEqual("_0", actual.First().Key);
         }
+
+        [Test]
+        public void ArgumentsToDictionaryShouldReturnInputParameterWhenInputParameterIsDictionary()
+        {
+            var binder = new TestInvokeMemberBinder("Test", false, new CallInfo(1, "Foo"));
+            var input = new Dictionary<string, object> { { "Test1", 1 }, { "Test2", 2 } };
+            var actual = binder.ArgumentsToDictionary(new object[] { input });
+            Assert.AreEqual(input["Test2"], actual["Test2"]);
+        }
     }
 
     class TestInvokeMemberBinder : InvokeMemberBinder

--- a/Simple.Data/BinderHelper.cs
+++ b/Simple.Data/BinderHelper.cs
@@ -21,7 +21,11 @@ namespace Simple.Data
 
         public static IDictionary<string, object> ArgumentsToDictionary(this InvokeMemberBinder binder, IEnumerable<object> args)
         {
-            return args.Reverse()
+            var argsArray = args.ToArray();
+            if (argsArray.Length == 1 && argsArray[0] is IDictionary<string, object>)
+                return (IDictionary<string, object>)argsArray[0];
+
+            return argsArray.Reverse()
                 .Zip(binder.CallInfo.ArgumentNames.Reverse().ExtendInfinite(), (v, k) => new KeyValuePair<string, object>(k, v))
                 .Reverse()
                 .Select((kvp, i) => kvp.Key == null ? new KeyValuePair<string, object>("_" + i.ToString(), kvp.Value) : kvp)


### PR DESCRIPTION
In this patch I changed the BinderHelper.ArgumentsToDictionary() method to detect when a single parameter of type `IDictionary<string, object>` is provided and to return it unmodified.

The motivation for this change is to be able to call a stored procedure with a simple IDictionary<> generated by reflecting over the properties of a "Data Model" class, instead of having to type out each parameter name and value manually in the method call.

---

Example:

```
Instead of:
```

```var blog = new Blog();
var comment = new Comment();
var db = Database.OpenConnection(connectionString);
db.UpdateBlogEntry(blogid: blog.BlogId, text: Blog.Text, ..., p50: blog.Parameter50, ..., pN)
db.UpdateComment(blogid: comment.BlogId, text: comment.Text, ..., p50: comment.Parameter50, ..., pN)

``````

    I can do:

```var blog = new Blog();
var comment = new Comment();
var db = Database.OpenConnection(connectionString);
db.UpdateBlogEntry(blog.ToIDictionaryFromPropertiesExtensionMethod());
db.UpdateComment(comment.ToIDictionaryFromPropertiesExtensionMethod());
``````
