### PR TITLE
Updated OrderBy and ThenBy to accept a direction param.

### DIFF
--- a/Simple.Data.BehaviourTest/NaturalNamingTest.cs
+++ b/Simple.Data.BehaviourTest/NaturalNamingTest.cs
@@ -46,6 +46,22 @@ namespace Simple.Data.IntegrationTest
         }
 
         [Test]
+        public void SortOrderIsCorrectlyResolvedInOrderByExpression()
+        {
+            _db.Customers.FindAll(_db.Customers.CustomerName == "Arthur").OrderBy(_db.Customers.CustomerName, OrderByDirection.Descending).ToList<dynamic>();
+            GeneratedSqlIs("select [dbo].[customers].[customerid],[dbo].[customers].[customer_name] from [dbo].[customers] where [dbo].[customers].[customer_name] = @p1 order by [customer_name] desc");
+            Parameter(0).Is("Arthur");
+        }
+
+        [Test]
+        public void SortOrderIsCorrectlyResolvedInOrderByThenByExpression()
+        {
+            _db.Customers.FindAll(_db.Customers.CustomerName == "Arthur").OrderBy(_db.Customers.CustomerName, OrderByDirection.Descending).ThenBy(_db.Customers.CustomerId, OrderByDirection.Ascending).ToList<dynamic>();
+            GeneratedSqlIs("select [dbo].[customers].[customerid],[dbo].[customers].[customer_name] from [dbo].[customers] where [dbo].[customers].[customer_name] = @p1 order by [customer_name] desc, [customerid]");
+            Parameter(0).Is("Arthur");
+        }
+
+        [Test]
         public void DotNetNamingInComplexQuery()
         {
             _db.CustomerOrders.FindAll(_db.CustomerOrders.CustomerId.Like("123%") || (_db.CustomerOrders.CustomerId == null)).ToList<dynamic>();

--- a/Simple.Data.UnitTest/SimpleQueryTest.cs
+++ b/Simple.Data.UnitTest/SimpleQueryTest.cs
@@ -46,6 +46,15 @@ namespace Simple.Data.UnitTest
         }
 
         [Test]
+        public void OrderByWithDescendingDirectionShouldSetOrderDescending()
+        {
+            var query = new SimpleQuery(null, "foo");
+            query = query.OrderBy(new ObjectReference("bar"), OrderByDirection.Descending);
+            Assert.AreEqual("bar", query.Clauses.OfType<OrderByClause>().Single().Reference.GetName());
+            Assert.AreEqual(OrderByDirection.Descending, query.Clauses.OfType<OrderByClause>().Single().Direction);
+        }
+
+        [Test]
         public void OrderByBarShouldSetOrderAscending()
         {
             dynamic query = new SimpleQuery(null, "foo");
@@ -63,6 +72,18 @@ namespace Simple.Data.UnitTest
             Assert.AreEqual("quux", actual.Clauses.OfType<OrderByClause>().Skip(1).First().Reference.GetName().ToLowerInvariant());
             Assert.AreEqual(OrderByDirection.Ascending, actual.Clauses.OfType<OrderByClause>().First().Direction);
             Assert.AreEqual(OrderByDirection.Ascending, actual.Clauses.OfType<OrderByClause>().Skip(1).First().Direction);
+        }
+
+        [Test]
+        public void OrderByBarThenQuxxShouldBeAbleToMixOrdering()
+        {
+            var query = new SimpleQuery(null, "foo");
+            query = query.OrderBy(new ObjectReference("bar"), OrderByDirection.Ascending)
+                         .ThenBy(new ObjectReference("quux"), OrderByDirection.Descending);
+            Assert.AreEqual("bar", query.Clauses.OfType<OrderByClause>().First().Reference.GetName());
+            Assert.AreEqual("quux", query.Clauses.OfType<OrderByClause>().Skip(1).First().Reference.GetName());
+            Assert.AreEqual(OrderByDirection.Ascending, query.Clauses.OfType<OrderByClause>().First().Direction);
+            Assert.AreEqual(OrderByDirection.Descending, query.Clauses.OfType<OrderByClause>().Skip(1).First().Direction);
         }
         
         [Test]

--- a/Simple.Data/OrderByClause.cs
+++ b/Simple.Data/OrderByClause.cs
@@ -9,14 +9,10 @@ namespace Simple.Data
         private readonly ObjectReference _reference;
         private readonly OrderByDirection _direction;
 
-        public OrderByClause(ObjectReference reference) : this(reference, OrderByDirection.Ascending)
-        {
-        }
-
-        public OrderByClause(ObjectReference reference, OrderByDirection direction)
+        public OrderByClause(ObjectReference reference, OrderByDirection? direction = null)
         {
             _reference = reference;
-            _direction = direction;
+            _direction = direction.HasValue ? direction.Value : OrderByDirection.Ascending;
         }
 
         public OrderByDirection Direction

--- a/Simple.Data/SimpleQuery.cs
+++ b/Simple.Data/SimpleQuery.cs
@@ -153,9 +153,9 @@
             return new SimpleQuery(this, _clauses.Append(new WhereClause(criteria)));
         }
 
-        public SimpleQuery OrderBy(ObjectReference reference)
+        public SimpleQuery OrderBy(ObjectReference reference, OrderByDirection? direction = null)
         {
-            return new SimpleQuery(this, _clauses.Append(new OrderByClause(reference)));
+            return new SimpleQuery(this, _clauses.Append(new OrderByClause(reference, direction)));
         }
 
         public SimpleQuery OrderByDescending(ObjectReference reference)
@@ -163,11 +163,11 @@
             return new SimpleQuery(this, _clauses.Append(new OrderByClause(reference, OrderByDirection.Descending)));
         }
 
-        public SimpleQuery ThenBy(ObjectReference reference)
+        public SimpleQuery ThenBy(ObjectReference reference, OrderByDirection? direction = null)
         {
             ThrowIfNoOrderByClause("ThenBy requires an existing OrderBy");
 
-            return new SimpleQuery(this, _clauses.Append(new OrderByClause(reference)));
+            return new SimpleQuery(this, _clauses.Append(new OrderByClause(reference, direction)));
         }
 
         private void ThrowIfNoOrderByClause(string message)


### PR DESCRIPTION
So now you can do things like:

_db.Customers.FindAll(_db.Customers.CustomerName == "Arthur")
.OrderBy(_db.Customers.CustomerName, OrderByDirection.Descending)
.ThenBy(_db.Customers.CustomerId);

Useful when your sort order is passed in as a parameter, such as
when binding the data to a DataTables table :-)
