### PR TITLE
Fixed issue with 'default' sort order and aliased first column

### DIFF
--- a/Simple.Data.SqlServer/SqlQueryPager.cs
+++ b/Simple.Data.SqlServer/SqlQueryPager.cs
@@ -54,6 +54,13 @@ namespace Simple.Data.SqlServer
             else
             {
                 orderBy = "ORDER BY " + columns.Split(',').First().Trim();
+
+                var aliasIndex = orderBy.IndexOf(" AS [", StringComparison.InvariantCultureIgnoreCase);
+
+                if (aliasIndex > -1)
+                {
+                    orderBy = orderBy.Substring(0, aliasIndex);
+                }
             }
             return orderBy;
         }

--- a/Simple.Data.SqlTest/SqlQueryPagerTest.cs
+++ b/Simple.Data.SqlTest/SqlQueryPagerTest.cs
@@ -54,5 +54,19 @@ namespace Simple.Data.SqlTest
 
             Assert.AreEqual(expected, modified);
         }
+
+        [Test]
+        public void ShouldCopeWithAliasedDefaultSortColumn()
+        {
+            const string sql = "select [a] as [foo],[b],[c] from [d] where [a] = 1";
+            const string expected =
+                "with __data as (select [a] as [foo],[b],[c], row_number() over(order by [a]) as [_#_] from [d] where [a] = 1)"
+                + " select [foo],[b],[c] from __data where [_#_] between @skip + 1 and @skip + @take";
+
+            var modified = new SqlQueryPager().ApplyPaging(sql, "@skip", "@take");
+            modified = Normalize.Replace(modified, " ").ToLowerInvariant();
+
+            Assert.AreEqual(expected, modified);
+        }
     }
 }


### PR DESCRIPTION
Fix for #100

May affect other providers too though.
