### PR TITLE
Fix for issues 105, 106 & 109

### DIFF
--- a/Simple.Data.Ado/AdoAdapter.IAdapterWithFunctions.cs
+++ b/Simple.Data.Ado/AdoAdapter.IAdapterWithFunctions.cs
@@ -18,7 +18,7 @@ namespace Simple.Data.Ado
 
 	    public IEnumerable<ResultSet> Execute(string functionName, IDictionary<string, object> parameters)
 	    {
-	        var executor = _executors.GetOrAdd(functionName, f => _connectionProvider.GetProcedureExecutor(this, ObjectName.Parse(f)));
+	        var executor = _executors.GetOrAdd(functionName, f => _connectionProvider.GetProcedureExecutor(this, _schema.BuildObjectName(f)));
 	        return executor.Execute(parameters);
 	    }
 	}

--- a/Simple.Data.Ado/CommandBuilder.cs
+++ b/Simple.Data.Ado/CommandBuilder.cs
@@ -255,9 +255,20 @@ namespace Simple.Data.Ado
 
         private static IDbDataParameter CreateSingleParameter(IDbParameterFactory parameterFactory, object value, ParameterTemplate template)    
         {
-            if (template.Column != null) return CreateSingleParameter(parameterFactory, value, template.Name, template.Column);
+            if (template.Column != null)
+            {
+                return CreateSingleParameter(parameterFactory, value, template.Name, template.Column);
+            }
 
-            var parameter = parameterFactory.CreateParameter(template.Name, template.DbType, template.MaxLength);
+            var parameter = default(IDbDataParameter);
+            if (template.Type == ParameterType.NameOnly)
+            {
+                parameter = parameterFactory.CreateParameter(template.Name);
+            }
+            else
+            {
+                parameter = parameterFactory.CreateParameter(template.Name, template.DbType, template.MaxLength);
+            }
             parameter.Value = CommandHelper.FixObjectType(value);
             return parameter;
         }

--- a/Simple.Data.Ado/CommandTemplate.cs
+++ b/Simple.Data.Ado/CommandTemplate.cs
@@ -120,11 +120,21 @@ namespace Simple.Data.Ado
         private IDbDataParameter CreateParameter(IDbCommand command, ParameterTemplate parameterTemplate, object value, string suffix = "")
         {
             var factory = _createGetParameterFactoryFunc(command);
-            var parameter = parameterTemplate.Column != null
-                                ? factory.CreateParameter(parameterTemplate.Name + suffix,
-                                                          parameterTemplate.Column)
-                                : factory.CreateParameter(parameterTemplate.Name, parameterTemplate.DbType,
-                                                          parameterTemplate.MaxLength);
+            var parameter = default(IDbDataParameter);
+            if(parameterTemplate.Column != null)
+            {
+                parameter = factory.CreateParameter(parameterTemplate.Name + suffix,
+                                                    parameterTemplate.Column);
+            }
+            else if (parameterTemplate.Type == ParameterType.NameOnly)
+            {
+                parameter = factory.CreateParameter(parameterTemplate.Name);
+            }
+            else
+            {
+                parameter = factory.CreateParameter(parameterTemplate.Name, parameterTemplate.DbType,
+                                                    parameterTemplate.MaxLength);
+            }
             parameter.Value = FixObjectType(value);
             return parameter;
         }

--- a/Simple.Data.Ado/GenericDbParameterFactory.cs
+++ b/Simple.Data.Ado/GenericDbParameterFactory.cs
@@ -14,6 +14,14 @@ namespace Simple.Data.Ado
             _command = command;
         }
 
+        public IDbDataParameter CreateParameter(string name)
+        {
+            if (name == null) throw new ArgumentNullException("name");
+            var parameter = _command.CreateParameter();
+            parameter.ParameterName = name;
+            return parameter;
+        }
+        
         public IDbDataParameter CreateParameter(string name, Column column)
         {
             if (name == null) throw new ArgumentNullException("name");

--- a/Simple.Data.Ado/IDbParameterFactory.cs
+++ b/Simple.Data.Ado/IDbParameterFactory.cs
@@ -6,6 +6,7 @@
 
     public interface IDbParameterFactory
     {
+        IDbDataParameter CreateParameter(string name);
         IDbDataParameter CreateParameter(string name, Column column);
         IDbDataParameter CreateParameter(string name, DbType dbType, int maxLength);
     }

--- a/Simple.Data.Ado/Joiner.cs
+++ b/Simple.Data.Ado/Joiner.cs
@@ -67,7 +67,7 @@ namespace Simple.Data.Ado
             {
                 var builder = new StringBuilder(JoinKeyword);
                 builder.AppendFormat(" JOIN {0}{1} ON ({2})",
-                    _schema.FindTable(ObjectName.Parse(join.Table.ToString())).QualifiedName,
+                    _schema.FindTable(_schema.BuildObjectName(join.Table.ToString())).QualifiedName,
                     string.IsNullOrWhiteSpace(join.Table.Alias) ? string.Empty : " " + _schema.QuoteObjectName(join.Table.Alias),
                     expressionFormatter.Format(join.JoinExpression));
                 yield return builder.ToString().Trim();

--- a/Simple.Data.Ado/ObjectName.cs
+++ b/Simple.Data.Ado/ObjectName.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Simple.Data.Ado.Schema;
 
 namespace Simple.Data.Ado
 {
@@ -22,15 +23,6 @@ namespace Simple.Data.Ado
             if (name == null) throw new ArgumentNullException("name");
             _schema = schema;
             _name = name;
-        }
-
-        public static ObjectName Parse(string text)
-        {
-            if (text == null) throw new ArgumentNullException("text");
-            if (!text.Contains('.')) return new ObjectName(Properties.Settings.Default.DefaultSchema ?? "dbo", text);
-            var schemaDotTable = text.Split('.');
-            if (schemaDotTable.Length != 2) throw new InvalidOperationException("Could not parse table name.");
-            return new ObjectName(schemaDotTable[0], schemaDotTable[1]);
         }
 
         public string Name

--- a/Simple.Data.Ado/ParameterTemplate.cs
+++ b/Simple.Data.Ado/ParameterTemplate.cs
@@ -27,7 +27,7 @@ namespace Simple.Data.Ado
             _column = column;
             if (column == null)
             {
-                _type = ParameterType.Other;
+                _type = ParameterType.NameOnly;
                 return;
             }
             _type = ParameterType.Column;
@@ -116,6 +116,7 @@ namespace Simple.Data.Ado
     {
         Column,
         FixedValue,
-        Other
+        Other,
+        NameOnly
     }
 }

--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -74,7 +74,8 @@ namespace Simple.Data.Ado
             command.Connection.Open();
             using (var reader = command.ExecuteReader())
             {
-                if (reader.FieldCount > 0)
+                // Reader isn't always returned - added check to stop NullReferenceException
+                if ((reader != null) && (reader.FieldCount > 0))
                 {
                     return reader.ToMultipleDictionaries();
                 }

--- a/Simple.Data.Ado/QueryBuilder.cs
+++ b/Simple.Data.Ado/QueryBuilder.cs
@@ -70,7 +70,7 @@ namespace Simple.Data.Ado
             _havingCriteria = _query.Clauses.OfType<HavingClause>().Aggregate(SimpleExpression.Empty,
                                                                               (seed, having) => seed && having.Criteria);
 
-            _tableName = ObjectName.Parse(query.TableName.Split('.').Last());
+            _tableName = _schema.BuildObjectName(query.TableName.Split('.').Last());
             _table = _schema.FindTable(_tableName);
             _commandBuilder.SetText(GetSelectClause(_tableName));
         }

--- a/Simple.Data.Ado/Schema/DatabaseSchema.cs
+++ b/Simple.Data.Ado/Schema/DatabaseSchema.cs
@@ -63,6 +63,11 @@ namespace Simple.Data.Ado.Schema
             return _lazyProcedures.Value.Find(procedureName);
         }
 
+        private String GetDefaultSchema()
+        {
+            return _schemaProvider.GetDefaultSchema();
+        }
+        
         private TableCollection CreateTableCollection()
         {
             return new TableCollection(_schemaProvider.GetTables()
@@ -100,6 +105,15 @@ namespace Simple.Data.Ado.Schema
         public static void ClearCache()
         {
             Instances.Clear();
+        }
+
+        public ObjectName BuildObjectName(String text)
+        {
+            if (text == null) throw new ArgumentNullException("text");
+            if (!text.Contains('.')) return new ObjectName(this.GetDefaultSchema(), text);
+            var schemaDotTable = text.Split('.');
+            if (schemaDotTable.Length != 2) throw new InvalidOperationException("Could not parse table name.");
+            return new ObjectName(schemaDotTable[0], schemaDotTable[1]);
         }
     }
 }

--- a/Simple.Data.Ado/Schema/ISchemaProvider.cs
+++ b/Simple.Data.Ado/Schema/ISchemaProvider.cs
@@ -13,5 +13,6 @@ namespace Simple.Data.Ado.Schema
         IEnumerable<ForeignKey> GetForeignKeys(Table table);
         string QuoteObjectName(string unquotedName);
         string NameParameter(string baseName);
+        string GetDefaultSchema();
     }
 }

--- a/Simple.Data.Mocking/Ado/MockSchemaProvider.cs
+++ b/Simple.Data.Mocking/Ado/MockSchemaProvider.cs
@@ -154,6 +154,9 @@ namespace Simple.Data.Mocking.Ado
             _tables.Clear();
         }
 
-        
+        public String GetDefaultSchema()
+        {
+            return "dbo";
+        }
     }
 }

--- a/Simple.Data.SqlCe40/SqlCe40SchemaProvider.cs
+++ b/Simple.Data.SqlCe40/SqlCe40SchemaProvider.cs
@@ -165,5 +165,10 @@ namespace Simple.Data.SqlCe40
 
             return dataTable;
         }
+
+        public String GetDefaultSchema()
+        {
+            return "dbo";
+        }
     }
 }

--- a/Simple.Data.SqlCe40/SqlCeDbParameterFactory.cs
+++ b/Simple.Data.SqlCe40/SqlCeDbParameterFactory.cs
@@ -16,6 +16,14 @@
             return new SqlCeParameter(name, sqlCeColumn.SqlDbType, 0, column.ActualName);
         }
 
+        public IDbDataParameter CreateParameter(string name)
+        {
+            return new SqlCeParameter
+                {
+                    ParameterName = name
+                };
+        }
+
         public IDbDataParameter CreateParameter(string name, DbType dbType, int maxLength)
         {
             IDbDataParameter parameter = new SqlCeParameter

--- a/Simple.Data.SqlServer/SqlCeDbParameterFactory.cs
+++ b/Simple.Data.SqlServer/SqlCeDbParameterFactory.cs
@@ -9,9 +9,17 @@
     [Export(typeof(IDbParameterFactory))]
     public class SqlDbParameterFactory : IDbParameterFactory
     {
+        public IDbDataParameter CreateParameter(string name)
+        {
+            return new SqlParameter
+                {
+                    ParameterName = name
+                };
+        }
+
         public IDbDataParameter CreateParameter(string name, Column column)
         {
-            var sqlColumn = (SqlColumn) column;
+            var sqlColumn = (SqlColumn)column;
             return new SqlParameter(name, sqlColumn.SqlDbType, column.MaxLength, column.ActualName);
         }
 

--- a/Simple.Data.SqlServer/SqlSchemaProvider.cs
+++ b/Simple.Data.SqlServer/SqlSchemaProvider.cs
@@ -189,5 +189,10 @@ namespace Simple.Data.SqlServer
         {
             return DbTypeLookup.GetSqlDbType(informationSchemaTypeName);
         }
+
+        public String GetDefaultSchema()
+        {
+            return "dbo";
+        }
     }
 }


### PR DESCRIPTION
Resolved issue 105 as proposed in the issue text

---

Resolves issue 106 as proposed in the issue text - this is needed for SqlServer and SqlAnywhere type inference.

This can be observed on HavingWithMinDateShouldReturnCorrectRow and HavingWithMaxDateShouldReturnCorrectRow where the DateTime value parameter is actually passed the DBMS as AnsiString:-

exec sp_executesql N'select [dbo].[GroupTestMaster].[Id],[dbo].[GroupTestMaster].[Name] from [dbo].[GroupTestMaster]  JOIN [dbo].[GroupTestDetail] ON ([dbo].[GroupTestMaster].[Id] = [dbo].[GroupTestDetail].[MasterId]) GROUP BY [dbo].[GroupTestMaster].[Id],[dbo].[GroupTestMaster].[Name] HAVING Min([dbo].[GroupTestDetail].[Date]) >= <b>@p1',N'@p1 varchar(19)',@p1='01/01/2000 00:00:00'</b>

---

Resolves issue 109 by adding a check for null in ProcedureExecutor.  Since this would never be null in existing code this has no impact on the current codebase, but makes way for the unexpected behaviour of other ADO.net providers (namely SqlAnywhere!) 
