### PR TITLE
Partial resolve issue 107, Resolve issue 113 & 114

### DIFF
--- a/Simple.Data.Ado/CommandHelper.cs
+++ b/Simple.Data.Ado/CommandHelper.cs
@@ -21,7 +21,7 @@ namespace Simple.Data.Ado
             _schemaProvider = adapter.SchemaProvider;
         }
 
-        internal IDbCommand Create(IDbConnection connection, string sql, IList<object> values)
+        internal IDbCommand Create(IDbConnection connection, string sql, Object[] values)
         {
             var command = connection.CreateCommand();
 
@@ -96,7 +96,7 @@ namespace Simple.Data.Ado
             return sqlBuilder.ToString();
         }
 
-        public static void SetParameterValues(IDbCommand command, IList<object> values)
+        public static void SetParameterValues(IDbCommand command, Object[] values)
         {
             int index = 0;
             foreach (var parameter in command.Parameters.Cast<IDbDataParameter>())
@@ -144,5 +144,15 @@ namespace Simple.Data.Ado
             return command;
 
         }
+
+        internal IDbCommand CreateInsert(IDbConnection connection, string sql, IEnumerable<Column> columns, Object[] values)
+        {
+            var command = connection.CreateCommand();
+
+            command.CommandText = PrepareInsertCommand(sql, command, columns);
+            SetParameterValues(command, values);
+
+            return command;
+        }       
     }
 }

--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -97,8 +97,16 @@ namespace Simple.Data.Ado
 
         private static void SetParameters(Procedure procedure, IDbCommand cmd, IDictionary<string, object> suppliedParameters)
         {
-            if (procedure.Parameters.Any(p => p.Direction == ParameterDirection.ReturnValue))
-                AddReturnParameter(cmd);
+            var returnParameter = procedure.Parameters.FirstOrDefault(p => p.Direction == ParameterDirection.ReturnValue);
+            if (returnParameter!=null)
+            {
+                var cmdParameter = cmd.CreateParameter();
+                cmdParameter.ParameterName = SimpleReturnParameterName;
+                cmdParameter.Size = returnParameter.Size;
+                cmdParameter.Direction = ParameterDirection.ReturnValue;
+                cmdParameter.DbType = returnParameter.Dbtype;
+                cmd.Parameters.Add(cmdParameter);
+            }
 
             int i = 0;
             
@@ -129,14 +137,6 @@ namespace Simple.Data.Ado
                 cmd.Parameters.Add(cmdParameter);
                 i++;
             }
-        }
-
-        private static void AddReturnParameter(IDbCommand cmd)
-        {
-            var returnParameter = cmd.CreateParameter();
-            returnParameter.ParameterName = SimpleReturnParameterName;
-            returnParameter.Direction = ParameterDirection.ReturnValue;
-            cmd.Parameters.Add(returnParameter);
         }
 
     }

--- a/Simple.Data.SqlServer/SqlSchemaProvider.cs
+++ b/Simple.Data.SqlServer/SqlSchemaProvider.cs
@@ -41,10 +41,26 @@ namespace Simple.Data.SqlServer
             return cols.AsEnumerable().Select(row => SchemaRowToColumn(table, row));
         }
 
+
+
         private static Column SchemaRowToColumn(Table table, DataRow row)
         {
-            return new SqlColumn(row["name"].ToString(), table, (bool) row["is_identity"],
-                              DbTypeFromInformationSchemaTypeName((string) row["type_name"]), (short) row["max_length"]);
+            var sqlDbType = DbTypeFromInformationSchemaTypeName((string)row["type_name"]);
+            var size = (short)row["max_length"];
+            switch (sqlDbType)
+            {
+                case SqlDbType.Image:
+                case SqlDbType.NText:
+                case SqlDbType.Text:
+                    size = -1;
+                    break;
+                case SqlDbType.NChar:
+                case SqlDbType.NVarChar:
+                    size = (short)(size / 2);
+                    break;
+            }
+
+            return new SqlColumn(row["name"].ToString(), table, (bool)row["is_identity"], sqlDbType, size);
         }
 
         public IEnumerable<Procedure> GetStoredProcedures()


### PR DESCRIPTION
This resolves the issue that prompted me to raise issue 107 (Set return parameter Size & DbType) which caused an issue with SQL Anywhere. The issue was that the return parameter was created without a type, so it defaulted to AnsiString however where the data type of the return value is not Char as it's not cast by the ADO.NET Provider so no value is returned.

---

This resolves issue 113 by providing the columns to a new CreateInsert on the CommandHelper class.  The code is based on the existing CreateInsert method used by BulkInserter that passes columns but not values and the Create method used by AdoAdapterInserter that passes values but not columns

---

This resolves issue 114 by adding additional logic to preprocess the values from the DataRow when constructing the SqlColumn
