### PR TITLE
Resolve issue 118

### DIFF
--- a/Simple.Data.Ado/Joiner.cs
+++ b/Simple.Data.Ado/Joiner.cs
@@ -149,7 +149,7 @@ namespace Simple.Data.Ado
             if (expression.Type == SimpleExpressionType.And || expression.Type == SimpleExpressionType.Or)
             {
                 return GetReferencesFromExpression((SimpleExpression)expression.LeftOperand)
-                    .Concat(GetReferencesFromExpression((SimpleExpression)expression.LeftOperand));
+                    .Concat(GetReferencesFromExpression((SimpleExpression)expression.RightOperand));
             }
 
             return Enumerable.Empty<ObjectReference>()

--- a/Simple.Data.SqlTest/NaturalJoinTest.cs
+++ b/Simple.Data.SqlTest/NaturalJoinTest.cs
@@ -31,5 +31,34 @@ namespace Simple.Data.SqlTest
                 Assert.AreEqual(1, order.OrderId);
             }
         }
+
+        [Test]
+        public void CustomerDotNameAndCustomerDotOrdersDotOrderItemsDotItemDotNameShouldReturnOneRow()
+        {
+            var db = DatabaseHelper.Open();
+            var customer = db.Customers.Find(db.Customers.Name == "Test" &&
+                                             db.Customers.Orders.OrderItems.Item.Name == "Widget");
+            Assert.IsNotNull(customer);
+            Assert.AreEqual("Test", customer.Name);
+            foreach (var order in customer.Orders)
+            {
+                Assert.AreEqual(1, order.OrderId);
+            }
+        }
+
+        [Test]
+        public void CustomerDotNameAndCustomerDotOrdersDotOrderDateAndCustomerDotOrdersDotOrderItemsDotItemDotNameShouldReturnOneRow()
+        {
+            var db = DatabaseHelper.Open();
+            var customer = db.Customers.Find(db.Customers.Name == "Test" &&
+                                             db.Customers.Orders.OrderDate == new DateTime(2010, 10, 10) &&
+                                             db.Customers.Orders.OrderItems.Item.Name == "Widget");
+            Assert.IsNotNull(customer);
+            Assert.AreEqual("Test", customer.Name);
+            foreach (var order in customer.Orders)
+            {
+                Assert.AreEqual(1, order.OrderId);
+            }
+        }
     }
 }


### PR DESCRIPTION
This resolves issue 118 by tweaking the Joiner to process the left and right operand rather than the left operand twice.  Also introduces two tests for this scenario.
