### PR TITLE
Multi command paging support & GetCustomProvider failover

### DIFF
--- a/Simple.Data.Ado.Test/ProviderHelperTest.cs
+++ b/Simple.Data.Ado.Test/ProviderHelperTest.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using System.Data;
+using Simple.Data.Ado.Schema;
+using System.ComponentModel.Composition;
+
+namespace Simple.Data.Ado.Test
+{
+    [TestFixture]
+    public class ProviderHelperTest
+    {
+        [Test]
+        public void ShouldNotRequestExportableTypeFromServiceProvider()
+        {
+            var helper = new ProviderHelper();
+            var connectionProvider = new StubConnectionAndServiceProvider();
+            var actual = helper.GetCustomProvider<ITestInterface>(connectionProvider);
+            Assert.IsNull(connectionProvider.RequestedServiceType);
+        }
+
+        [Test]
+        public void ShouldRequestNonExportedTypeFromServiceProvider()
+        {
+            var helper = new ProviderHelper();
+            var connectionProvider = new StubConnectionAndServiceProvider();
+            var actual = helper.GetCustomProvider<IQueryPager>(connectionProvider);
+            Assert.AreEqual(typeof(IQueryPager), connectionProvider.RequestedServiceType);
+        }
+
+        [Test]
+        public void ShouldReturnNonExportedTypeFromServiceProvider()
+        {
+            var helper = new ProviderHelper();
+            var connectionProvider = new StubConnectionAndServiceProvider();
+            var actual = helper.GetCustomProvider<IQueryPager>(connectionProvider);
+            Assert.IsInstanceOf(typeof(IQueryPager), actual);
+        }
+
+        public class StubConnectionAndServiceProvider : IConnectionProvider, IServiceProvider
+        {
+            public void SetConnectionString(string connectionString)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IDbConnection CreateConnection()
+            {
+                throw new NotImplementedException();
+            }
+
+            public ISchemaProvider GetSchemaProvider()
+            {
+                throw new NotImplementedException();
+            }
+
+            public string ConnectionString
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public bool SupportsCompoundStatements
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public string GetIdentityFunction()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool SupportsStoredProcedures
+            {
+                get { throw new NotImplementedException(); }
+            }
+
+            public IProcedureExecutor GetProcedureExecutor(AdoAdapter adapter, ObjectName procedureName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Type RequestedServiceType { get; private set; }
+            public Object GetService(Type serviceType)
+            {
+                this.RequestedServiceType = serviceType;
+                return new StubQueryPager();
+            }
+        }
+
+        public class StubQueryPager : IQueryPager
+        {
+            public IEnumerable<string> ApplyPaging(string sql, int skip, int take)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public interface ITestInterface { }
+        [Export(typeof(ITestInterface))]
+        public class TestClass : ITestInterface { }
+    }
+}

--- a/Simple.Data.Ado.Test/Simple.Data.Ado.Test.csproj
+++ b/Simple.Data.Ado.Test/Simple.Data.Ado.Test.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="AdoAdapterExceptionTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ProviderHelperTest.cs" />
     <Compile Include="TableCollectionTest.cs" />
     <Compile Include="TestCustomInserter.cs" />
     <Compile Include="ProviderTest.cs" />

--- a/Simple.Data.Ado/CommandBuilder.cs
+++ b/Simple.Data.Ado/CommandBuilder.cs
@@ -41,6 +41,15 @@ namespace Simple.Data.Ado
             _parameterSuffix = (bulkIndex >= 0) ? "_c" + bulkIndex : string.Empty;
         }
 
+        public CommandBuilder(string text, DatabaseSchema schema, IEnumerable<KeyValuePair<ParameterTemplate, Object>> parameters)
+            : this(text, schema, -1)
+        {
+            foreach (var kvp in parameters)
+            {
+                _parameters.Add(kvp.Key, kvp.Value);
+            }
+        }
+
         public ParameterTemplate AddParameter(object value)
         {
             string name = _schemaProvider.NameParameter("p" + Interlocked.Increment(ref _number) + _parameterSuffix);

--- a/Simple.Data.Ado/DataReaderEnumerator.cs
+++ b/Simple.Data.Ado/DataReaderEnumerator.cs
@@ -45,7 +45,7 @@ namespace Simple.Data.Ado
             {
                 ExecuteReader();
             }
-            return _lastRead = _reader.Read();
+            return _lastRead = (_reader != null && _reader.Read());
         }
 
         private void ExecuteReader()
@@ -55,7 +55,10 @@ namespace Simple.Data.Ado
                 if (_connection.State == ConnectionState.Closed)
                     _connection.Open();
                 _reader = _command.ExecuteReader();
-                _index = _index ?? _reader.CreateDictionaryIndex();
+                if (_reader != null)
+                {
+                    _index = _index ?? _reader.CreateDictionaryIndex();
+                }
             }
             catch (DbException ex)
             {
@@ -73,6 +76,10 @@ namespace Simple.Data.Ado
         {
             get
             {
+                if (_reader == null)
+                {
+                    return null;
+                }
                 if (!_lastRead) throw new InvalidOperationException();
                 return _reader.ToDictionary(_index);
             }

--- a/Simple.Data.Ado/IQueryPager.cs
+++ b/Simple.Data.Ado/IQueryPager.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
+
 namespace Simple.Data.Ado
 {
     public interface IQueryPager
     {
-        string ApplyPaging(string sql, string skipParameterName, string takeParameterName);
+        IEnumerable<string> ApplyPaging(string sql, int skip, int take);
     }
 }

--- a/Simple.Data.SqlCe40/SqlCe40QueryPager.cs
+++ b/Simple.Data.SqlCe40/SqlCe40QueryPager.cs
@@ -13,7 +13,7 @@ namespace Simple.Data.SqlCe40
     {
         private static readonly Regex ColumnExtract = new Regex(@"SELECT\s*(.*)\s*(FROM.*)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
         
-        public string ApplyPaging(string sql, string skipParameterName, string takeParameterName)
+        public IEnumerable<string> ApplyPaging(string sql, int skip, int take)
         {
             if (sql.IndexOf("order by", StringComparison.InvariantCultureIgnoreCase) < 0)
             {
@@ -22,7 +22,7 @@ namespace Simple.Data.SqlCe40
                 sql += " ORDER BY " + columns.Split(',').First().Trim();
             }
 
-            return string.Format("{0} OFFSET {1} ROWS FETCH NEXT {2} ROWS ONLY", sql, skipParameterName, takeParameterName);
+            yield return string.Format("{0} OFFSET {1} ROWS FETCH NEXT {2} ROWS ONLY", sql, skip, take);
         }
     }
 }

--- a/Simple.Data.SqlCe40Test/SqlCe40QueryPagerTest.cs
+++ b/Simple.Data.SqlCe40Test/SqlCe40QueryPagerTest.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Simple.Data.SqlCe40;
+using System.Linq;
 
 namespace Simple.Data.SqlCe40Test
 {
@@ -12,27 +13,27 @@ namespace Simple.Data.SqlCe40Test
         [Test]
         public void ShouldApplyPagingUsingOrderBy()
         {
-            const string sql = "select a,b,c from d where a = 1 order by c";
-            const string expected =
-                "select a,b,c from d where a = 1 order by c offset @skip rows fetch next @take rows only";
+            var sql = "select a,b,c from d where a = 1 order by c";
+            var expected = new[]{
+                "select a,b,c from d where a = 1 order by c offset 5 rows fetch next 10 rows only"};
 
-            var modified = new SqlCe40QueryPager().ApplyPaging(sql, "@skip", "@take");
-            modified = Normalize.Replace(modified, " ").ToLowerInvariant();
+            var pagedSql = new SqlCe40QueryPager().ApplyPaging(sql, 5, 10);
+            var modified = pagedSql.Select(x=> Normalize.Replace(x, " ").ToLowerInvariant());
 
-            Assert.AreEqual(expected, modified);
+            Assert.IsTrue(expected.SequenceEqual(modified));
         }
 
         [Test]
         public void ShouldApplyPagingUsingOrderByFirstColumnIfNotAlreadyOrdered()
         {
-            const string sql = "select a,b,c from d where a = 1";
-            const string expected =
-                "select a,b,c from d where a = 1 order by a offset @skip rows fetch next @take rows only";
+            var sql = "select a,b,c from d where a = 1";
+            var expected = new[]{
+                "select a,b,c from d where a = 1 order by a offset 10 rows fetch next 20 rows only"};
 
-            var modified = new SqlCe40QueryPager().ApplyPaging(sql, "@skip", "@take");
-            modified = Normalize.Replace(modified, " ").ToLowerInvariant();
+            var pagedSql = new SqlCe40QueryPager().ApplyPaging(sql, 10, 20);
+            var modified = pagedSql.Select(x => Normalize.Replace(x, " ").ToLowerInvariant());
 
-            Assert.AreEqual(expected, modified);
+            Assert.IsTrue(expected.SequenceEqual(modified));
         }
     }
 }

--- a/Simple.Data.SqlServer/SqlQueryPager.cs
+++ b/Simple.Data.SqlServer/SqlQueryPager.cs
@@ -13,7 +13,7 @@ namespace Simple.Data.SqlServer
     {
         private static readonly Regex ColumnExtract = new Regex(@"SELECT\s*(.*)\s*(FROM.*)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
-        public string ApplyPaging(string sql, string skipParameterName, string takeParameterName)
+        public IEnumerable<string> ApplyPaging(string sql, int skip, int take)
         {
             var builder = new StringBuilder("WITH __Data AS (SELECT ");
 
@@ -29,10 +29,10 @@ namespace Simple.Data.SqlServer
             builder.AppendLine();
             builder.Append(fromEtc);
             builder.AppendLine(")");
-            builder.AppendFormat("SELECT {0} FROM __Data WHERE [_#_] BETWEEN {1} + 1 AND {1} + {2}", DequalifyColumns(columns),
-                                 skipParameterName, takeParameterName);
+            builder.AppendFormat("SELECT {0} FROM __Data WHERE [_#_] BETWEEN {1} AND {2}", DequalifyColumns(columns),
+                                 skip + 1, skip + take);
 
-            return builder.ToString();
+            yield return builder.ToString();
         }
 
         private static string DequalifyColumns(string original)

--- a/Simple.Data.SqlTest/SqlQueryPagerTest.cs
+++ b/Simple.Data.SqlTest/SqlQueryPagerTest.cs
@@ -16,57 +16,57 @@ namespace Simple.Data.SqlTest
         [Test]
         public void ShouldApplyPagingUsingOrderBy()
         {
-            const string sql = "select a,b,c from d where a = 1 order by c";
-            const string expected =
+            var sql = "select a,b,c from d where a = 1 order by c";
+            var expected = new[]{
                 "with __data as (select a,b,c, row_number() over(order by c) as [_#_] from d where a = 1)"
-                + " select a,b,c from __data where [_#_] between @skip + 1 and @skip + @take";
+                + " select a,b,c from __data where [_#_] between 6 and 15"};
 
-            var modified = new SqlQueryPager().ApplyPaging(sql, "@skip", "@take");
-            modified = Normalize.Replace(modified, " ").ToLowerInvariant();
+            var pagedSql = new SqlQueryPager().ApplyPaging(sql, 5, 10);
+            var modified = pagedSql.Select(x => Normalize.Replace(x, " ").ToLowerInvariant());
 
-            Assert.AreEqual(expected, modified);
+            Assert.IsTrue(expected.SequenceEqual(modified));
         }
 
         [Test]
         public void ShouldApplyPagingUsingOrderByFirstColumnIfNotAlreadyOrdered()
         {
-            const string sql = "select a,b,c from d where a = 1";
-            const string expected =
+            var sql = "select a,b,c from d where a = 1";
+            var expected = new[]{
                 "with __data as (select a,b,c, row_number() over(order by a) as [_#_] from d where a = 1)"
-                + " select a,b,c from __data where [_#_] between @skip + 1 and @skip + @take";
+                + " select a,b,c from __data where [_#_] between 11 and 30"};
 
-            var modified = new SqlQueryPager().ApplyPaging(sql, "@skip", "@take");
-            modified = Normalize.Replace(modified, " ").ToLowerInvariant();
+            var pagedSql = new SqlQueryPager().ApplyPaging(sql, 10, 20);
+            var modified = pagedSql.Select(x => Normalize.Replace(x, " ").ToLowerInvariant());
 
-            Assert.AreEqual(expected, modified);
+            Assert.IsTrue(expected.SequenceEqual(modified));
         }
 
         [Test]
         public void ShouldCopeWithAliasedColumns()
         {
-            const string sql = "select [a],[b] as [foo],[c] from [d] where [a] = 1";
-            const string expected =
+            var sql = "select [a],[b] as [foo],[c] from [d] where [a] = 1";
+            var expected =new[]{
                 "with __data as (select [a],[b] as [foo],[c], row_number() over(order by [a]) as [_#_] from [d] where [a] = 1)"
-                + " select [a],[foo],[c] from __data where [_#_] between @skip + 1 and @skip + @take";
+                + " select [a],[foo],[c] from __data where [_#_] between 21 and 25"};
 
-            var modified = new SqlQueryPager().ApplyPaging(sql, "@skip", "@take");
-            modified = Normalize.Replace(modified, " ").ToLowerInvariant();
+            var pagedSql = new SqlQueryPager().ApplyPaging(sql, 20, 5);
+            var modified = pagedSql.Select(x => Normalize.Replace(x, " ").ToLowerInvariant());
 
-            Assert.AreEqual(expected, modified);
+            Assert.IsTrue(expected.SequenceEqual(modified));
         }
 
         [Test]
         public void ShouldCopeWithAliasedDefaultSortColumn()
         {
-            const string sql = "select [a] as [foo],[b],[c] from [d] where [a] = 1";
-            const string expected =
+            var sql = "select [a] as [foo],[b],[c] from [d] where [a] = 1";
+            var expected = new[]{
                 "with __data as (select [a] as [foo],[b],[c], row_number() over(order by [a]) as [_#_] from [d] where [a] = 1)"
-                + " select [foo],[b],[c] from __data where [_#_] between @skip + 1 and @skip + @take";
+                + " select [foo],[b],[c] from __data where [_#_] between 31 and 40"};
 
-            var modified = new SqlQueryPager().ApplyPaging(sql, "@skip", "@take");
-            modified = Normalize.Replace(modified, " ").ToLowerInvariant();
+            var pagedSql = new SqlQueryPager().ApplyPaging(sql, 30, 10);
+            var modified = pagedSql.Select(x => Normalize.Replace(x, " ").ToLowerInvariant());
 
-            Assert.AreEqual(expected, modified);
+            Assert.IsTrue(expected.SequenceEqual(modified));
         }
     }
 }

--- a/Simple.Data/SimpleResultSet.cs
+++ b/Simple.Data/SimpleResultSet.cs
@@ -315,6 +315,7 @@ namespace Simple.Data
         public static SimpleResultSet Create(IEnumerable<IDictionary<string, object>> source, string tableName, DataStrategy dataStrategy)
         {
             var q = from dict in source
+                    where dict != null
                     select new SimpleRecord(dict, tableName, dataStrategy);
             return new SimpleResultSet(q);
         }


### PR DESCRIPTION
This allows connection plugins to provide multiple commands to do paging when multiple SQL statements per command is not supported, for example:-
1, Setup an in-memory temporary table with paged data.
2, Select paged values from temporary table.
3, Drop temporary table.

This feature is required for SqlAnywhere 8.0.3 which doesn't support the WITH statement or host variables in batches!

Also added the ability to hand over to the IConnectionProvider the responsibility to create services if it also implements the standard IServiceProvider interface.  This will allow intelligent provision of services based on the database connection that is already in place.

This feature is needed for SqlAnywhere to ensure the most efficient IQueryPager is used based on the varying support offered by each version from 8.0.3 up to 12.0.1.  
