### PR TITLE
InMemory Adapter - AutoIncrement handles Insert without auto incremented column specified

### DIFF
--- a/Simple.Data.InMemoryTest/InMemoryTests.cs
+++ b/Simple.Data.InMemoryTest/InMemoryTests.cs
@@ -51,7 +51,7 @@
             var db = Database.Open();
             db.Test.Insert(Id: 1, Name: "Alice");
             db.Test.Insert(Id: 2, Name: "Bob");
-            List<IDictionary<string,object>> records = db.Test.All().Select(db.Test.Name).ToList<IDictionary<string,object>>();
+            List<IDictionary<string, object>> records = db.Test.All().Select(db.Test.Name).ToList<IDictionary<string, object>>();
             Assert.IsNotNull(records);
             Assert.AreEqual(2, records.Count);
             Assert.False(records[0].ContainsKey("Id"));
@@ -125,7 +125,7 @@
         {
             Database.UseMockAdapter(new InMemoryAdapter());
             var db = Database.Open();
-            db.Test.Insert(Id: 1, Data: new byte[] {0x1, 0x2, 0x3});
+            db.Test.Insert(Id: 1, Data: new byte[] { 0x1, 0x2, 0x3 });
             var record = db.Test.FindById(1);
             Assert.AreEqual(0x1, record.Data[0]);
         }
@@ -250,7 +250,7 @@
         }
 
         [Test]
-        public void find_all_when_using_Name_property_should_work()
+        public void FindAllWhenUsingNamePropertyShouldWork()
         {
             var adapter = new InMemoryAdapter();
             adapter.ConfigureJoin("Users", "Id", "Categories", "Categories", "UserId", "User");
@@ -264,11 +264,11 @@
 
             var categories = db.Users.FindAll(db.User.Categories.Name == "Category 1").ToList();
             Assert.NotNull(categories);
-            Assert.AreEqual(1, categories.Count); // FAILS - Count == 0
+            Assert.AreEqual(1, categories.Count); 
         }
 
         [Test]
-        public void find_all_when_using_CategoryName_property_should_work()
+        public void FindAllWhenUsingAnyOldPropertyNameShouldWork()
         {
             var adapter = new InMemoryAdapter();
             adapter.ConfigureJoin("Users", "Id", "Categories", "Categories", "UserId", "User");
@@ -282,7 +282,42 @@
 
             var categories = db.Users.FindAll(db.User.Categories.CategoryName == "Category 1").ToList();
             Assert.NotNull(categories);
-            Assert.AreEqual(1, categories.Count); // Works find  - Count == 1
+            Assert.AreEqual(1, categories.Count); 
+        }
+
+        [Test]
+        public void AutoIncrementShouldSet1ForAutoIncrementedColumnsWhenNoRowsInTable()
+        {
+            // Arrange
+            var adapter = new InMemoryAdapter();
+            adapter.SetAutoIncrementColumn("Users", "Id");
+
+            Database.UseMockAdapter(adapter);
+            var db = Database.Open();
+
+            // Act
+            var newId = db.Users.Insert(Name: "Marcus").Id;
+
+            // Assert
+            Assert.AreEqual(1, newId);
+        }
+
+        [Test]
+        public void AutoIncrementShouldReturnNextIdInSequenceWhenOneRowExsists()
+        {
+            // Arrange
+            var adapter = new InMemoryAdapter();
+            adapter.SetAutoIncrementColumn("Users", "Id");
+
+            Database.UseMockAdapter(adapter);
+            var db = Database.Open();
+            db.Users.Insert(Name: "Marcus");
+
+            // Act
+            var newId = db.Users.Insert(Name: "Per").Id;
+
+            // Assert
+            Assert.AreEqual(2, newId);
         }
 
         private static int ThreadTestHelper(int userId)

--- a/Simple.Data/InMemoryAdapter.cs
+++ b/Simple.Data/InMemoryAdapter.cs
@@ -56,10 +56,24 @@
         {
             if (_autoIncrementColumns.ContainsKey(tableName))
             {
-                object nextVal = GetTable(tableName).Select(d => d[_autoIncrementColumns[tableName]]).Max();
+                var table = GetTable(tableName);
+                var autoIncrementColumn = _autoIncrementColumns[tableName];
+
+                if(!data.ContainsKey(autoIncrementColumn))
+                {
+                    data.Add(autoIncrementColumn, 0);
+                }
+
+                object nextVal = 0;
+                if(table.Count > 0)
+                {
+                    nextVal = table.Select(d => d[autoIncrementColumn]).Max(); ;
+                }
+                
                 nextVal = ObjectMaths.Increment(nextVal);
-                data[_autoIncrementColumns[tableName]] = nextVal;
+                data[autoIncrementColumn] = nextVal;
             }
+
             GetTable(tableName).Add(data);
 
             AddAsDetail(tableName, data);


### PR DESCRIPTION
I've implemented a version of AutoIncrement that handles that you don't specify the column your increment, as you commonly do for tables. 
