### PR TITLE
Fix for issue #116

### DIFF
--- a/Simple.Data.Ado/DataReaderEnumerator.cs
+++ b/Simple.Data.Ado/DataReaderEnumerator.cs
@@ -11,6 +11,7 @@ namespace Simple.Data.Ado
 
     internal class DataReaderEnumerator : IEnumerator<IDictionary<string, object>>
     {
+        private readonly IDisposable _connectionDisposable;
         private readonly IDbConnection _connection;
         private IDictionary<string, int> _index;
         private readonly IDbCommand _command;
@@ -26,12 +27,13 @@ namespace Simple.Data.Ado
         {
             _command = command;
             _connection = connection;
+            _connectionDisposable = _connection.MaybeDisposable();
             _index = index;
         }
 
         public void Dispose()
         {
-            using (_connection)
+            using (_connectionDisposable)
             using (_command)
             using (_reader)
             {


### PR DESCRIPTION
This fixes issue #116.

Implemented the same behavior as DataReaderMultipleEnumerator in DataReaderEnumerator by using the _connection.MaybeDisposable() method, and using that in Dispose() instead.
