### PR TITLE
Minor change in EntityPluralizer implementation

### DIFF
--- a/Simple.Data.UnitTest/PluralizationTest.cs
+++ b/Simple.Data.UnitTest/PluralizationTest.cs
@@ -116,7 +116,7 @@ namespace Simple.Data.UnitTest
     class EntityPluralizer : IPluralizer
     {
         private readonly PluralizationService _pluralizationService =
-            PluralizationService.CreateService(CultureInfo.CurrentCulture);
+            PluralizationService.CreateService(new CultureInfo("en-US"));
 
         public bool IsPlural(string word)
         {


### PR DESCRIPTION
EntityPluralizer that is used in unit tests is based on EntityFramework PluralizationService. Currently EF PluralizationService only supports English locales, so attempt to run pluralization tests on a machine with non-English culture results in the following exception:

TestFixture failed: System.NotImplementedException : We don't support locales other than english yet
   at System.Data.Entity.Design.PluralizationServices.PluralizationService.CreateService(CultureInfo culture)
   at Simple.Data.UnitTest.EntityPluralizer..ctor() in C:\Projects\Git\Simple.Data\Simple.Data.UnitTest\PluralizationTest.cs:line 118
   at Simple.Data.UnitTest.PluralizationTest.FixtureSetup() in C:\Projects\Git\Simple.Data\Simple.Data.UnitTest\PluralizationTest.cs:line 15

Changing culture info to en-US in PluralizationService.CreateService call resolves this error.
