### PR TITLE
Update to AdoAdapterTransaction

### DIFF
--- a/Simple.Data.Ado/AdoAdapter.cs
+++ b/Simple.Data.Ado/AdoAdapter.cs
@@ -154,7 +154,7 @@ namespace Simple.Data.Ado
             IDbConnection connection = CreateConnection();
             connection.OpenIfClosed();
             IDbTransaction transaction = connection.BeginTransaction();
-            return new AdoAdapterTransaction(transaction);
+            return new AdoAdapterTransaction(transaction, _sharedConnection != null);
         }
 
         public IAdapterTransaction BeginTransaction(string name)
@@ -166,7 +166,7 @@ namespace Simple.Data.Ado
                                              ? sqlConnection.BeginTransaction(name)
                                              : connection.BeginTransaction();
 
-            return new AdoAdapterTransaction(transaction, name);
+            return new AdoAdapterTransaction(transaction, name, _sharedConnection != null);
         }
 
         public IEnumerable<IDictionary<string, object>> Find(string tableName, SimpleExpression criteria,
@@ -578,7 +578,7 @@ namespace Simple.Data.Ado
             IDbConnection connection = CreateConnection();
             connection.OpenIfClosed();
             IDbTransaction transaction = connection.BeginTransaction(isolationLevel);
-            return new AdoAdapterTransaction(transaction);
+            return new AdoAdapterTransaction(transaction, _sharedConnection != null);
         }
 
         public IAdapterTransaction BeginTransaction(IsolationLevel isolationLevel, string name)
@@ -590,7 +590,7 @@ namespace Simple.Data.Ado
                                              ? sqlConnection.BeginTransaction(isolationLevel, name)
                                              : connection.BeginTransaction(isolationLevel);
 
-            return new AdoAdapterTransaction(transaction, name);
+            return new AdoAdapterTransaction(transaction, name, _sharedConnection != null);
         }
 
         public string GetIdentityFunction()

--- a/Simple.Data.Ado/AdoAdapterTransaction.cs
+++ b/Simple.Data.Ado/AdoAdapterTransaction.cs
@@ -12,16 +12,18 @@ namespace Simple.Data.Ado
         private readonly string _name;
         private readonly IDbTransaction _dbTransaction;
         private readonly IDbConnection _dbConnection;
+        private readonly bool _sharedConnection;
 
-        public AdoAdapterTransaction(IDbTransaction dbTransaction) : this(dbTransaction, null)
+        public AdoAdapterTransaction(IDbTransaction dbTransaction, bool sharedConnection = false) : this(dbTransaction, null, sharedConnection)
         {
         }
 
-        public AdoAdapterTransaction(IDbTransaction dbTransaction, string name)
+        public AdoAdapterTransaction(IDbTransaction dbTransaction, string name, bool sharedConnection = false)
         {
             _name = name;
             _dbTransaction = dbTransaction;
             _dbConnection = _dbTransaction.Connection;
+            _sharedConnection = sharedConnection;
         }
 
         internal IDbTransaction Transaction
@@ -32,7 +34,8 @@ namespace Simple.Data.Ado
         public void Dispose()
         {
             _dbTransaction.Dispose();
-            _dbConnection.Dispose();
+            if (!_sharedConnection)
+                _dbConnection.Dispose();
         }
 
         public void Commit()


### PR DESCRIPTION
I was unable to perform multiple database transactions on the same shared connection because when the transaction committed it was automatically disposing the connection. 

This alters the AdoAdapterTransaction so that it only disposes the connection if it is not shared.
