### PR TITLE
fix for nested collections that are not complex types.

### DIFF
--- a/Simple.Data.UnitTest/SimpleResultSetTest.cs
+++ b/Simple.Data.UnitTest/SimpleResultSetTest.cs
@@ -392,10 +392,33 @@
             Assert.AreEqual(1, converted.Count());
             Assert.AreEqual("0", converted.First().Data);
         }
+
+        [Test]
+        public void CastToGenericCreatesTypedListWithSubTypes()
+        {
+            var firstRecord = new SimpleRecord(new Dictionary<string, object>
+            {
+                { "Data", "First" },
+                { "List", new List<string> { "First-One", "First-Two" } }
+            });
+
+            var list = new SimpleResultSet(new List<dynamic> { firstRecord });
+
+            var result = list.Cast<TestType2>().First();
+
+            Assert.AreEqual(2, result.List.Count);
+        }
     }
 
     class TestType
     {
         public string Data { get; set; }
+    }
+
+    class TestType2
+    {
+        public string Data { get; set; }
+
+        public List<string> List { get; set; }
     }
 }


### PR DESCRIPTION
PropertySetterBuilder made the assumption that all nested collections were complex types.  This fix alters the expression tree created to test for an IEnumerable[object] if the test for IEnumerable[IDictionary[string,object]] fails and then simply converts each element to the target type and adds them to the collection.
