### PR TITLE
Failing test case for Upsert on single column

### DIFF
--- a/Simple.Data.SqlTest/UpsertTests.cs
+++ b/Simple.Data.SqlTest/UpsertTests.cs
@@ -401,5 +401,17 @@ namespace Simple.Data.SqlTest
             blob = db.Blobs.FindById(1);
             Assert.IsTrue(image.SequenceEqual(blob.Data));
         }
+
+        [Test]
+        public void TestUpsertWithSingleArgumentAndExistingObject()
+        {
+            var db = DatabaseHelper.Open();
+
+            var actual = db.Users.UpsertById(Id: 1);
+
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(1, actual.Id);
+            Assert.AreEqual("Ford Prefect", actual.Name);
+        }
     }
 }


### PR DESCRIPTION
Upsert fails with Ado when you only specify a single column. This patch contains a failing test case. I am undecided between whether this should be fixed by changing the behaviour of Update to allow updating no data, or by changing Upsert to only update when there is data to change, so have not included a fix.
