### PR TITLE
Tests to confirm upsert in the InMemoryAdapter

### DIFF
--- a/Simple.Data.InMemoryTest/InMemoryTests.cs
+++ b/Simple.Data.InMemoryTest/InMemoryTests.cs
@@ -623,5 +623,33 @@
                 Assert.AreEqual("Bar", row.Foo);
             }
         }
+
+        [Test]
+        public void UpsertShouldAddNewRecord()
+        {
+            var adapter = new InMemoryAdapter();
+            adapter.SetKeyColumn("Test", "Id");
+            Database.UseMockAdapter(adapter);
+            var db = Database.Open();
+            db.Test.Upsert(Id: 1, SomeValue: "Testing");
+            var record = db.Test.Get(1);
+            Assert.IsNotNull(record);
+            Assert.AreEqual("Testing", record.SomeValue);
+        }
+
+        [Test]
+        public void UpsertShouldUpdateExistingRecord()
+        {
+            var adapater = new InMemoryAdapter();
+            adapater.SetKeyColumn("Test","Id");
+            Database.UseMockAdapter(adapater);
+            var db = Database.Open();
+            db.Test.Upsert(Id: 1, SomeValue: "Testing");
+            db.Test.Upsert(Id: 1, SomeValue: "Updated");
+            List<dynamic> allRecords = db.Test.All().ToList();
+            Assert.IsNotNull(allRecords);
+            Assert.AreEqual(1,allRecords.Count);
+            Assert.AreEqual("Updated", allRecords.Single().SomeValue);
+        }
     }
 }

--- a/Simple.Data.InMemoryTest/InMemoryTests.cs
+++ b/Simple.Data.InMemoryTest/InMemoryTests.cs
@@ -651,5 +651,15 @@
             Assert.AreEqual(1,allRecords.Count);
             Assert.AreEqual("Updated", allRecords.Single().SomeValue);
         }
+
+        [Test]
+        public void UpsertWithoutDefinedKeyColumnsSHouldThrowMeaningfulException()
+        {
+            var adapter = new InMemoryAdapter();
+            Database.UseMockAdapter(adapter);
+            var db = Database.Open();
+            var exception = Assert.Throws<InvalidOperationException>(() => db.Test.Upsert(Id: 1, HasTowel: true));
+            Assert.AreEqual("No key columns defined for table \"Test\"", exception.Message);
+        }
     }
 }

--- a/Simple.Data/Commands/UpsertCommand.cs
+++ b/Simple.Data/Commands/UpsertCommand.cs
@@ -49,7 +49,7 @@ namespace Simple.Data.Commands
             var dict = record as IDictionary<string, object>;
             if (dict == null) throw new InvalidOperationException("Could not resolve data from passed object.");
             var key = dataStrategy.GetAdapter().GetKey(table.GetQualifiedName(), dict);
-
+            if (key == null) throw new InvalidOperationException(string.Format("No key columns defined for table \"{0}\"",table.GetQualifiedName()));
             var criteria = ExpressionHelper.CriteriaDictionaryToExpression(table.GetQualifiedName(), key);
             return dataStrategy.Run.Upsert(table.GetQualifiedName(), dict, criteria, isResultRequired);
         }


### PR DESCRIPTION
closes #194 as it was just me not knowing to apply adapter.SetKeyColumn() before using key dependent functinality. 

Allso I've added a more meanginful exception. Changed from arbitrary ArgumentNullException to InvalidOperationException with eplanatory message.

The test for the new exception might be misplaced, as it really tests the upsert command and not the inmemoryadapter
