### PR TITLE
Where polyfills now correctly handle where...in clause

### DIFF
--- a/Simple.Data.InMemoryTest/InMemoryTests.cs
+++ b/Simple.Data.InMemoryTest/InMemoryTests.cs
@@ -36,6 +36,20 @@
         }
 
         [Test]
+        public void InsertAndFindAllShouldWork()
+        {
+            Database.UseMockAdapter(new InMemoryAdapter());
+            var db = Database.Open();
+            db.Test.Insert(Id: 1, Name: "Alice");
+            db.Test.Insert(Id: 2, Name: "Bob");
+            List<dynamic> records = db.Test.FindAllById(new[] { 1, 5 }).ToList();
+            var record = records.Single();
+            Assert.IsNotNull(record);
+            Assert.AreEqual(1, record.Id);
+            Assert.AreEqual("Alice", record.Name);
+        }
+
+        [Test]
         public void InsertAndFindWithTwoColumnsShouldWork()
         {
             Database.UseMockAdapter(new InMemoryAdapter());

--- a/Simple.Data.SqlTest/FindTests.cs
+++ b/Simple.Data.SqlTest/FindTests.cs
@@ -57,6 +57,14 @@ namespace Simple.Data.SqlTest
         }
 
         [Test]
+        public void TestFindAllByNameArray()
+        {
+            var db = DatabaseHelper.Open();
+            IEnumerable<User> users = db.Users.FindAllByName(new[] { "Bob", "UnknownUser" }).Cast<User>();
+            Assert.AreEqual(1, users.Count());
+        }
+
+        [Test]
         public void TestFindAllByNameAsIEnumerableOfDynamic()
         {
             var db = DatabaseHelper.Open();


### PR DESCRIPTION
The "where" polyfill didn't seem to handle where...in clauses correctly. I added two tests (for the InMemoryAdapter and for the SQL client) as well.
