### PR TITLE
Fix for 'multi-part identifier could not be bound' issue with aliased joins

### DIFF
--- a/Simple.Data.SqlTest/QueryTest.cs
+++ b/Simple.Data.SqlTest/QueryTest.cs
@@ -414,6 +414,21 @@ namespace Simple.Data.SqlTest
         }
 
         [Test]
+        public void WithClauseContainingAliasShouldReturnResults()
+        {
+            var db = DatabaseHelper.Open();
+            var actual = db.Customers
+                .With(db.Customers.Orders.As("Orders_1"))
+                .With(db.Customers.Orders.As("Orders_2"))
+                .FirstOrDefault();
+            Assert.IsNotNull(actual);
+            Assert.AreEqual(1, actual.Orders_1.Single().OrderId);
+            Assert.AreEqual(1, actual.Orders_2.Single().OrderId);
+            Assert.AreEqual(new DateTime(2010, 10, 10), actual.Orders_1.Single().OrderDate);
+            Assert.AreEqual(new DateTime(2010, 10, 10), actual.Orders_2.Single().OrderDate);
+        }
+
+        [Test]
         public void SelfJoinShouldNotThrowException()
         {
             var db = DatabaseHelper.Open();


### PR DESCRIPTION
Hey Mark, I contacted you on Twitter the other day with regarding this issue.  When I attempt to join via an alias the resulting SQL query text is invalid.  An error occurs stating that the multi-part identifier could not be bound.

I have included a unit test for the issue and also included a fix.  There is quite a bit of work going on to resolve join text so I may have missed something.  That said, all existing SQL tests pass with the exception of the TestUpdateWithJoinCriteriaOnCompoundKeyTable test.  However, that test never passed for me (could be because the CompoundKey\* tables are not created in the DatabaseReset script).  Also, I noticed that the resulting query performs an outer join where I would have expected an inner join.  What is the intent there?

I hope you find this pull request useful.  I'd appreciate your feedback too as this is my first pull request.  Awesome job on Simple.Data, it's a wonderful library!
