### PR TITLE
Fixed bug for paging in SqlServer

### DIFF
--- a/Simple.Data.SqlServer/SqlQueryPager.cs
+++ b/Simple.Data.SqlServer/SqlQueryPager.cs
@@ -38,7 +38,10 @@ namespace Simple.Data.SqlServer
             builder.AppendFormat("SELECT {0} FROM __Data ", columns);
             builder.AppendFormat("JOIN {0} ON ",
                                  keys[0].Substring(0, keys[0].LastIndexOf(".", StringComparison.OrdinalIgnoreCase)));
-            builder.AppendFormat(string.Join(" ", keys.Select(MakeDataJoin)));
+            if (keys.Length > 1)
+                builder.AppendFormat(string.Join(" AND ", keys.Select(MakeDataJoin)));
+            else
+                builder.AppendFormat(string.Join(" ", keys.Select(MakeDataJoin)));
             var rest = Regex.Replace(fromEtc, @"^from (\[.*?\]\.\[.*?\])", @"");
             builder.Append(rest);
             


### PR DESCRIPTION
SqlQueryPager.cs had a bug where the join got messed up with tables that had multiple primary keys.
