### PR TITLE
Improved exception messages and logging (fixed #273)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ obj
 bin
 deploy
 *.csproj.user
+*.DotSettings.user
 *.suo
 *.cache
 *.nupkg

--- a/Simple.Data.Ado/AdoAdapter.IAdapterWithTransactions.cs
+++ b/Simple.Data.Ado/AdoAdapter.IAdapterWithTransactions.cs
@@ -58,7 +58,7 @@
         public int Update(string tableName, IDictionary<string, object> data, IAdapterTransaction adapterTransaction)
         {
             string[] keyFieldNames = GetKeyNames(tableName).ToArray();
-            if (keyFieldNames.Length == 0) throw new AdoAdapterException("No Primary Key found for implicit update");
+            if (keyFieldNames.Length == 0) throw new AdoAdapterException(string.Format("No primary key found for implicit update of table '{0}'.", tableName));
             return Update(tableName, data, GetCriteria(tableName, keyFieldNames, data), adapterTransaction);
         }
 

--- a/Simple.Data.Ado/AdoAdapterException.cs
+++ b/Simple.Data.Ado/AdoAdapterException.cs
@@ -3,76 +3,74 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 using Simple.Data.Extensions;
 
 namespace Simple.Data.Ado
 {
-    using System.Security;
-
     [Serializable]
     public class AdoAdapterException : AdapterException
     {
         public AdoAdapterException() : base(typeof(AdoAdapter))
-        {
-        }
+        {}
 
-        public AdoAdapterException(string message, IDbCommand command) : base(message, typeof(AdoAdapter))
+        public AdoAdapterException(string message)
+            : base(message, typeof(AdoAdapter))
+        {}
+
+        public AdoAdapterException(string message, Exception inner)
+            : base(message, inner, typeof(AdoAdapter))
+        {}
+
+        public AdoAdapterException(string message, IDbCommand command)
+            : base(message, typeof(AdoAdapter))
         {
             CommandText = command.CommandText;
             Parameters = command.Parameters.Cast<IDbDataParameter>()
                 .ToDictionary(p => p.ParameterName, p => p.Value);
         }
 
-        public AdoAdapterException(string commandText, IEnumerable<KeyValuePair<string,object>> parameters)
-            :base(typeof(AdoAdapter))
+        public AdoAdapterException(string message, IDbCommand command, Exception inner)
+            : base(message, inner, typeof(AdoAdapter))
+        {
+            CommandText = command.CommandText;
+            Parameters = command.Parameters.Cast<IDbDataParameter>()
+                .ToDictionary(p => p.ParameterName, p => p.Value);
+        }
+
+        public AdoAdapterException(string commandText, IEnumerable<KeyValuePair<string, object>> parameters)
+            : base(typeof(AdoAdapter)) // never used outside tests?
         {
             CommandText = commandText;
             Parameters = parameters.ToDictionary();
         }
 
-
-        public AdoAdapterException(string message) : base(message, typeof(AdoAdapter))
-        {
-        }
-
-        public AdoAdapterException(string message, string commandText, IEnumerable<KeyValuePair<string,object>> parameters)
-            :base(message, typeof(AdoAdapter))
+        public AdoAdapterException(string message, string commandText, IEnumerable<KeyValuePair<string, object>> parameters)
+            : base(message, typeof(AdoAdapter))
         {
             CommandText = commandText;
             Parameters = parameters.ToDictionary();
         }
 
-        public AdoAdapterException(string message, Exception inner) : base(message, inner, typeof(AdoAdapter))
+        public AdoAdapterException(string message, string commandText, IEnumerable<KeyValuePair<string, object>> parameters, Exception inner)
+            : base(message, inner, typeof(AdoAdapter))
         {
+            CommandText = commandText;
+            Parameters = parameters.ToDictionary();
         }
 
         protected AdoAdapterException(SerializationInfo info, StreamingContext context)
             : base(info, context)
-        {
-            //CommandText = info.GetString("CommandText");
-            //try
-            //{
-            //    var array = info.GetValue("Parameters", typeof(KeyValuePair<string, object>[]));
-            //    if (array != null)
-            //    {
-            //        Parameters = ((KeyValuePair<string, object>[])array);
-            //    }
-            //}
-            //catch (SerializationException)
-            //{
-            //}
-        }
+        {}
 
         public IDictionary<string, object> Parameters
         {
-            get { return Data.Contains("Parameters") ?  ((KeyValuePair<string,object>[])Data["Parameters"]).ToDictionary() : null; }
+            get { return Data.Contains("Parameters") ? ((KeyValuePair<string, object>[])Data["Parameters"]).ToDictionary() : null; }
             private set { Data["Parameters"] = value.ToArray(); }
         }
 
         public string CommandText
         {
-            get { return Data.Contains("CommandText") ?  Data["CommandText"].ToString() : null; }
+            get { return Data.Contains("CommandText") ? Data["CommandText"].ToString() : null; }
             private set { Data["CommandText"] = value; }
         }
     }

--- a/Simple.Data.Ado/AdoAdapterFinder.cs
+++ b/Simple.Data.Ado/AdoAdapterFinder.cs
@@ -139,7 +139,7 @@
             }
             catch (DbException ex)
             {
-                throw new AdoAdapterException(ex.Message, command);
+                throw new AdoAdapterException(ex.Message, command, ex);
             }
         }
 
@@ -151,7 +151,7 @@
             }
             catch (DbException ex)
             {
-                throw new AdoAdapterException(ex.Message, command);
+                throw new AdoAdapterException(ex.Message, command, ex);
             }
         }
 

--- a/Simple.Data.Ado/AdoAdapterGetter.cs
+++ b/Simple.Data.Ado/AdoAdapterGetter.cs
@@ -35,7 +35,7 @@ namespace Simple.Data.Ado
         public Func<object[],IDictionary<string,object>> CreateGetDelegate(string tableName, params object[] keyValues)
         {
             var primaryKey = _adapter.GetSchema().FindTable(tableName).PrimaryKey;
-            if (primaryKey == null) throw new InvalidOperationException("Table has no primary key.");
+            if (primaryKey == null) throw new InvalidOperationException(string.Format("Table '{0}' has no primary key.", tableName));
             if (primaryKey.Length != keyValues.Length) throw new ArgumentException("Incorrect number of values for key.");
 
 
@@ -107,7 +107,7 @@ namespace Simple.Data.Ado
         public IDictionary<string, object> Get(string tableName, object[] parameterValues)
         {
             var primaryKey = _adapter.GetSchema().FindTable(tableName).PrimaryKey;
-            if (primaryKey == null) throw new InvalidOperationException("Table has no primary key.");
+            if (primaryKey == null) throw new InvalidOperationException(string.Format("Table '{0}' has no primary key.", tableName));
             if (primaryKey.Length != parameterValues.Length) throw new ArgumentException("Incorrect number of values for key.");
 
 

--- a/Simple.Data.Ado/AdoAdapterInserter.cs
+++ b/Simple.Data.Ado/AdoAdapterInserter.cs
@@ -98,7 +98,7 @@ namespace Simple.Data.Ado
 
             if (!data.Any())
             {
-                throw new SimpleDataException("No properties were found which could be mapped to the database.");
+                throw new SimpleDataException(string.Format("No properties were found which could be mapped to table '{0}'.", table.ActualName));
             }
         }
 

--- a/Simple.Data.Ado/AdoAdapterQueryRunner.cs
+++ b/Simple.Data.Ado/AdoAdapterQueryRunner.cs
@@ -185,7 +185,7 @@
                 var table = _adapter.GetSchema().FindTable(query.TableName);
                 if (table.PrimaryKey == null || table.PrimaryKey.Length == 0)
                 {
-                    throw new AdoAdapterException("Cannot apply paging to a table with no primary key.");
+                    throw new AdoAdapterException(string.Format("Cannot apply paging to table '{0}' with no primary key.", table.ActualName));
                 }
                 var keys = table.PrimaryKey.AsEnumerable()
                      .Select(k => string.Format("{0}.{1}", table.QualifiedName, _adapter.GetSchema().QuoteObjectName(k)))

--- a/Simple.Data.Ado/AdoAdapterQueryRunner.cs
+++ b/Simple.Data.Ado/AdoAdapterQueryRunner.cs
@@ -83,10 +83,10 @@
             {
                 withCountClause = query.Clauses.OfType<WithCountClause>().First();
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException e)
             {
                 // Rethrow with meaning.
-                throw new InvalidOperationException("No WithCountClause specified.");
+                throw new InvalidOperationException("No WithCountClause specified.", e);
             }
 
             query = query.ClearWithTotalCount();

--- a/Simple.Data.Ado/AdoAdapterQueryRunner.cs
+++ b/Simple.Data.Ado/AdoAdapterQueryRunner.cs
@@ -148,7 +148,8 @@
                 var queryPager = _adapter.ProviderHelper.GetCustomProvider<IQueryPager>(_adapter.ConnectionProvider);
                 if (queryPager == null)
                 {
-                    Trace.TraceWarning("There is no database-specific query paging in your current Simple.Data Provider. Paging will be done in memory.");
+                    SimpleDataTraceSources.TraceSource.TraceEvent(TraceEventType.Warning, SimpleDataTraceSources.PerformanceWarningMessageId,
+                        "There is no database-specific query paging in your current Simple.Data Provider. Paging will be done in memory.");
                     DeferPaging(ref query, mainCommandBuilder, commandBuilders, unhandledClausesList);
                 }
                 else

--- a/Simple.Data.Ado/AdoAdapterRelatedFinder.cs
+++ b/Simple.Data.Ado/AdoAdapterRelatedFinder.cs
@@ -30,7 +30,7 @@ namespace Simple.Data.Ado
         public object FindRelated(string tableName, IDictionary<string, object> row, string relatedTableName)
         {
             var join = TryJoin(tableName, relatedTableName);
-            if (join == null) throw new AdoAdapterException("Could not resolve relationship.");
+            if (join == null) throw new AdoAdapterException(string.Format("Could not resolve relationship of tables '{0}' and '{1}'.", tableName, relatedTableName));
 
             if (join.Master == _adapter.GetSchema().FindTable(tableName))
             {

--- a/Simple.Data.Ado/BulkInserterHelper.cs
+++ b/Simple.Data.Ado/BulkInserterHelper.cs
@@ -144,9 +144,10 @@ namespace Simple.Data.Ado
                 {
                     command.Prepare();
                 }
-                catch (InvalidOperationException)
+                catch (InvalidOperationException e)
                 {
-                    Trace.TraceWarning("Could not prepare command.");
+                    SimpleDataTraceSources.TraceSource.TraceEvent(TraceEventType.Warning, SimpleDataTraceSources.GenericWarningMessageId,
+                        "Could not prepare command: {0}", e.Message);
                 }
             }
         }

--- a/Simple.Data.Ado/DbCommandExtensions.cs
+++ b/Simple.Data.Ado/DbCommandExtensions.cs
@@ -87,7 +87,7 @@
         {
             return new AdoAdapterException(ex.Message, command.CommandText,
                                            command.Parameters.Cast<IDbDataParameter>()
-                                               .ToDictionary(p => p.ParameterName, p => p.Value));
+                                               .ToDictionary(p => p.ParameterName, p => p.Value), ex);
         }
 
         internal static void DisposeCommandAndReader(IDbConnection connection, IDbCommand command, IDataReader reader)

--- a/Simple.Data.Ado/Joiner.cs
+++ b/Simple.Data.Ado/Joiner.cs
@@ -111,7 +111,7 @@ namespace Simple.Data.Ado
 
             if (foreignKey == null)
                 throw new SchemaResolutionException(
-                    string.Format("Could not join '{0}' and '{1}'", table1.ActualName, table2.ActualName));
+                    string.Format("Could not join tables '{0}' and '{1}', foreign key not found.", table1.ActualName, table2.ActualName));
             return foreignKey;
         }
 

--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -40,7 +40,7 @@ namespace Simple.Data.Ado
             var procedure = _adapter.GetSchema().FindProcedure(_procedureName);
             if (procedure == null)
             {
-                throw new UnresolvableObjectException(_procedureName.ToString());
+                throw new UnresolvableObjectException(_procedureName.ToString(), string.Format("Procedure '{0}' not found.", _procedureName));
             }
 
             var cn = transaction == null ? _adapter.CreateConnection() : transaction.Connection;

--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -95,7 +95,7 @@ namespace Simple.Data.Ado
         private static IEnumerable<ResultSet> ExecuteNonQuery(IDbCommand command)
         {
 #if(DEBUG)
-            Trace.TraceInformation("ExecuteNonQuery", "Simple.Data.SqlTest");
+            SimpleDataTraceSources.TraceSource.TraceEvent(TraceEventType.Verbose, SimpleDataTraceSources.DebugMessageId, "Simple.Data.SqlTest ExecuteNonQuery");
 #endif
             command.Connection.OpenIfClosed();
             command.TryExecuteNonQuery();

--- a/Simple.Data.Ado/ProcedureExecutor.cs
+++ b/Simple.Data.Ado/ProcedureExecutor.cs
@@ -61,7 +61,7 @@ namespace Simple.Data.Ado
                 }
                 catch (DbException ex)
                 {
-                    throw new AdoAdapterException(ex.Message, command);
+                    throw new AdoAdapterException(ex.Message, command, ex);
                 }
             }
         }

--- a/Simple.Data.Ado/ProviderHelper.cs
+++ b/Simple.Data.Ado/ProviderHelper.cs
@@ -68,7 +68,7 @@ namespace Simple.Data.Ado
         {
             var extension = Path.GetExtension(filename);
 
-            if (extension == null) throw new ArgumentException("Unrecognised file.");
+            if (extension == null) throw new ArgumentException(string.Format("Unrecognised file name '{0}': no extension.", filename), "filename");
             return extension.TrimStart('.').ToLower();
         }
 
@@ -111,7 +111,7 @@ namespace Simple.Data.Ado
             provider = ComposeProvider(token.ProviderName);
             if (provider == null)
             {
-                throw new InvalidOperationException("Provider could not be resolved.");
+                throw new InvalidOperationException(string.Format("Provider '{0}' could not be resolved.", token.ProviderName));
             }
 
             provider.SetConnectionString(token.ConnectionString);

--- a/Simple.Data.Ado/Schema/ColumnCollection.cs
+++ b/Simple.Data.Ado/Schema/ColumnCollection.cs
@@ -26,7 +26,7 @@ namespace Simple.Data.Ado.Schema
         public Column Find(string columnName)
         {
             var column = FindColumnWithName(columnName);
-            if (column == null) throw new UnresolvableObjectException(columnName);
+            if (column == null) throw new UnresolvableObjectException(columnName, string.Format("Column '{0}' not found.", columnName));
             return column;
         }
 

--- a/Simple.Data.Ado/Schema/DatabaseSchema.cs
+++ b/Simple.Data.Ado/Schema/DatabaseSchema.cs
@@ -139,7 +139,7 @@ namespace Simple.Data.Ado.Schema
             if (text == null) throw new ArgumentNullException("text");
             if (!text.Contains('.')) return new ObjectName(this.DefaultSchema, text);
             var schemaDotTable = text.Split('.');
-            if (schemaDotTable.Length != 2) throw new InvalidOperationException("Could not parse table name.");
+            if (schemaDotTable.Length != 2) throw new InvalidOperationException(string.Format("Could not parse table name '{0}'.", text));
             return new ObjectName(schemaDotTable[0], schemaDotTable[1]);
         }
 

--- a/Simple.Data.Ado/Schema/ProcedureCollection.cs
+++ b/Simple.Data.Ado/Schema/ProcedureCollection.cs
@@ -56,7 +56,7 @@ namespace Simple.Data.Ado.Schema
             if (procedureName.Contains('.'))
             {
                 var schemaDotprocedure = procedureName.Split('.');
-                if (schemaDotprocedure.Length != 2) throw new InvalidOperationException("Could not resolve qualified procedure name.");
+                if (schemaDotprocedure.Length != 2) throw new InvalidOperationException(string.Format("Could not resolve qualified procedure name '{0}'.", procedureName));
                 return Find(schemaDotprocedure[1], schemaDotprocedure[0]);
             }
             if (!string.IsNullOrWhiteSpace(_defaultSchema))

--- a/Simple.Data.Ado/Schema/ProcedureCollection.cs
+++ b/Simple.Data.Ado/Schema/ProcedureCollection.cs
@@ -33,7 +33,7 @@ namespace Simple.Data.Ado.Schema
 
             if (procedure == null)
             {
-                throw new UnresolvableObjectException(procedureName, "No matching procedure found, or insufficient permissions.");
+                throw new UnresolvableObjectException(procedureName, string.Format("Procedure '{0}' not found, or insufficient permissions.", procedureName));
             }
 
             return procedure;
@@ -83,7 +83,8 @@ namespace Simple.Data.Ado.Schema
 
             if (procedure == null)
             {
-                throw new UnresolvableObjectException(schemaName + '.' + procedureName, "No matching procedure found, or insufficient permissions.");
+                string fullProcedureName = schemaName + '.' + procedureName;
+                throw new UnresolvableObjectException(fullProcedureName, string.Format("Procedure '{0}' not found, or insufficient permissions.", fullProcedureName));
             }
 
             return procedure;

--- a/Simple.Data.Ado/Schema/Table.cs
+++ b/Simple.Data.Ado/Schema/Table.cs
@@ -88,7 +88,8 @@ namespace Simple.Data.Ado.Schema
             }
             catch (UnresolvableObjectException ex)
             {
-                throw new UnresolvableObjectException(_actualName + "." + ex.ObjectName, "Column not found", ex);
+                string fullColumnName = _actualName + "." + ex.ObjectName;
+                throw new UnresolvableObjectException(fullColumnName, string.Format("Column '{0}' not found.", fullColumnName), ex);
             }
         }
 

--- a/Simple.Data.Ado/Schema/TableCollection.cs
+++ b/Simple.Data.Ado/Schema/TableCollection.cs
@@ -36,7 +36,7 @@ namespace Simple.Data.Ado.Schema
 
             if (table == null)
             {
-                throw new UnresolvableObjectException(tableName, "No matching table found, or insufficient permissions.");
+                throw new UnresolvableObjectException(tableName, string.Format("Table '{0}' not found, or insufficient permissions.", tableName));
             }
 
             return table;
@@ -66,7 +66,8 @@ namespace Simple.Data.Ado.Schema
 
             if (table == null)
             {
-                throw new UnresolvableObjectException(schemaName + '.' + tableName, "No matching table found, or insufficient permissions.");
+                string fullTableName = schemaName + '.' + tableName;
+                throw new UnresolvableObjectException(fullTableName, string.Format("Table '{0}' not found, or insufficient permissions.", fullTableName));
             }
 
             return table;

--- a/Simple.Data.Ado/SimpleReferenceFormatter.cs
+++ b/Simple.Data.Ado/SimpleReferenceFormatter.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace Simple.Data.Ado
 {
     using System;
@@ -99,7 +101,7 @@ namespace Simple.Data.Ado
                 case MathOperator.Modulo:
                     return _schema.Operators.Modulo;
                 default:
-                    throw new InvalidOperationException("Invalid MathOperator specified.");
+                    throw new InvalidEnumArgumentException("Invalid MathOperator specified.");
             }
         }
 

--- a/Simple.Data.Ado/TraceHelper.cs
+++ b/Simple.Data.Ado/TraceHelper.cs
@@ -21,11 +21,11 @@ namespace Simple.Data.Ado
                 sb.AppendFormat("SQL command (CommandType={0}):{1}  {2}", command.CommandType, EOL, command.CommandText);
                 if (command.Parameters.Count > 0)
                 {
-                    sb.AppendFormat("Parameters:{0}", EOL);
+                    sb.AppendFormat("{0}Parameters:", EOL);
                     foreach (var parameter in command.Parameters.OfType<DbParameter>())
                     {
                         object strValue = parameter.Value is string ? string.Format("\"{0}\"", parameter.Value) : parameter.Value;
-                        sb.AppendFormat("  {0} ({1}) = {2}{3}", parameter.ParameterName, parameter.DbType, strValue, EOL);
+                        sb.AppendFormat("{0}  {1} ({2}) = {3}", EOL, parameter.ParameterName, parameter.DbType, strValue);
                     }
                 }
                 SimpleDataTraceSources.TraceSource.TraceEvent(TraceEventType.Information, SimpleDataTraceSources.SqlMessageId, sb.ToString());

--- a/Simple.Data.BehaviourTest/NameResolutionTests.cs
+++ b/Simple.Data.BehaviourTest/NameResolutionTests.cs
@@ -78,7 +78,7 @@ namespace Simple.Data.IntegrationTest
         class EntityPluralizer : IPluralizer
         {
             private readonly PluralizationService _pluralizationService =
-                PluralizationService.CreateService(CultureInfo.CurrentCulture);
+                PluralizationService.CreateService(CultureInfo.GetCultureInfo("en-us")); // only English is supported
 
             public bool IsPlural(string word)
             {

--- a/Simple.Data.Mocking/Ado/MockSchemaProvider.cs
+++ b/Simple.Data.Mocking/Ado/MockSchemaProvider.cs
@@ -145,7 +145,7 @@ namespace Simple.Data.Mocking.Ado
         public string NameParameter(string baseName)
         {
             if (baseName == null) throw new ArgumentNullException("baseName");
-            if (baseName.Length == 0) throw new ArgumentException("Base name must be provided");
+            if (baseName.Length == 0) throw new ArgumentException("Base name must be provided", "baseName");
             return (baseName.StartsWith("@")) ? baseName : "@" + baseName;
         }
 

--- a/Simple.Data.Mocking/XmlMockAdapter.cs
+++ b/Simple.Data.Mocking/XmlMockAdapter.cs
@@ -144,7 +144,7 @@ namespace Simple.Data.Mocking
         private XElement GetTableElement(string tableName)
         {
             XElement tableElement = Data.Element(tableName);
-            if (tableElement == null) throw new UnresolvableObjectException(tableName);
+            if (tableElement == null) throw new UnresolvableObjectException(tableName, string.Format("Table '{0}' not found.", tableName));
             return tableElement;
         }
 

--- a/Simple.Data.SqlCe40/SqlCe40SchemaProvider.cs
+++ b/Simple.Data.SqlCe40/SqlCe40SchemaProvider.cs
@@ -112,7 +112,7 @@ namespace Simple.Data.SqlCe40
         public string NameParameter(string baseName)
         {
             if (baseName == null) throw new ArgumentNullException("baseName");
-            if (baseName.Length == 0) throw new ArgumentException("Base name must be provided");
+            if (baseName.Length == 0) throw new ArgumentException("Base name must be provided", "baseName");
             return (baseName.StartsWith("@")) ? baseName : "@" + baseName;
         }
 

--- a/Simple.Data.SqlServer/SqlSchemaProvider.cs
+++ b/Simple.Data.SqlServer/SqlSchemaProvider.cs
@@ -150,7 +150,7 @@ namespace Simple.Data.SqlServer
         public string NameParameter(string baseName)
         {
             if (baseName == null) throw new ArgumentNullException("baseName");
-            if (baseName.Length == 0) throw new ArgumentException("Base name must be provided");
+            if (baseName.Length == 0) throw new ArgumentException("Base name must be provided", "baseName");
             return (baseName.StartsWith("@")) ? baseName : "@" + baseName;
         }
 

--- a/Simple.Data.sln.DotSettings
+++ b/Simple.Data.sln.DotSettings
@@ -1,0 +1,7 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE_SHIFTED_2</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_EMPTY_METHOD_PARENTHESES/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_METHOD_PARENTHESES/@EntryValue">False</s:Boolean></wpf:ResourceDictionary>

--- a/Simple.Data/BadExpressionException.cs
+++ b/Simple.Data/BadExpressionException.cs
@@ -1,37 +1,21 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace Simple.Data
 {
     [Serializable]
-    public class BadExpressionException : Exception
+    public class BadExpressionException : ArgumentException
     {
-        //
-        // For guidelines regarding the creation of new exception types, see
-        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/cpgenref/html/cpconerrorraisinghandlingguidelines.asp
-        // and
-        //    http://msdn.microsoft.com/library/default.asp?url=/library/en-us/dncscol/html/csharp07192001.asp
-        //
-
         public BadExpressionException()
-        {
-        }
+        {}
 
         public BadExpressionException(string message) : base(message)
-        {
-        }
+        {}
 
         public BadExpressionException(string message, Exception inner) : base(message, inner)
-        {
-        }
+        {}
 
-        protected BadExpressionException(
-            SerializationInfo info,
-            StreamingContext context) : base(info, context)
-        {
-        }
+        protected BadExpressionException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {}
     }
 }

--- a/Simple.Data/DynamicTable.cs
+++ b/Simple.Data/DynamicTable.cs
@@ -129,7 +129,8 @@ namespace Simple.Data
         {
             if (binder.Name == "All")
             {
-                Trace.WriteLine("The dynamic 'All' property is deprecated; use the 'All()' method instead.");
+                SimpleDataTraceSources.TraceSource.TraceEvent(TraceEventType.Warning, SimpleDataTraceSources.ObsoleteWarningMessageId,
+                    "The dynamic 'All' property is deprecated; use the 'All()' method instead.");
                 result = GetAll().ToList();
                 return true;
             }

--- a/Simple.Data/InMemoryAdapter.cs
+++ b/Simple.Data/InMemoryAdapter.cs
@@ -373,7 +373,7 @@
 
         public IEnumerable<IEnumerable<IEnumerable<KeyValuePair<string, object>>>> Execute(string functionName, IDictionary<string, object> parameters)
         {
-            if (!_functions.ContainsKey(functionName)) throw new InvalidOperationException("No function found with that name.");
+            if (!_functions.ContainsKey(functionName)) throw new InvalidOperationException(string.Format("Function '{0}' not found.", functionName));
             var obj = _functions[functionName].DynamicInvoke(parameters.Values.ToArray());
 
             var dict = obj as IDictionary<string, object>;

--- a/Simple.Data/MefHelper.cs
+++ b/Simple.Data/MefHelper.cs
@@ -53,7 +53,8 @@ namespace Simple.Data
             }
             catch (ReflectionTypeLoadException ex)
             {
-                Trace.WriteLine(ex.Message);
+                SimpleDataTraceSources.TraceSource.TraceEvent(TraceEventType.Error, SimpleDataTraceSources.GenericErrorMessageId,
+                    "Compose failed: {0}", ex.Message);
                 throw;
             }
         }
@@ -71,15 +72,15 @@ namespace Simple.Data
 
         private static CompositionContainer CreateFolderContainer()
         {
-			var path = GetSimpleDataAssemblyPath ();
+            var path = GetSimpleDataAssemblyPath ();
 
             var assemblyCatalog = new AssemblyCatalog(ThisAssembly);
-			var aggregateCatalog = new AggregateCatalog(assemblyCatalog);
-			foreach (string file in System.IO.Directory.GetFiles(path, "Simple.Data.*.dll"))
-			{
-				var catalog = new AssemblyCatalog(file);
-				aggregateCatalog.Catalogs.Add(catalog);
-			}
+            var aggregateCatalog = new AggregateCatalog(assemblyCatalog);
+            foreach (string file in System.IO.Directory.GetFiles(path, "Simple.Data.*.dll"))
+            {
+                var catalog = new AssemblyCatalog(file);
+                aggregateCatalog.Catalogs.Add(catalog);
+            }
             return new CompositionContainer(aggregateCatalog);
         }
 

--- a/Simple.Data/Properties/AssemblyInfo.cs
+++ b/Simple.Data/Properties/AssemblyInfo.cs
@@ -23,3 +23,4 @@ using System.Security.Permissions;
 [assembly: SecurityRules(SecurityRuleSet.Level2, SkipVerificationInFullTrust = true)]
 [assembly: AllowPartiallyTrustedCallers]
 [assembly: InternalsVisibleTo("Simple.Data.InMemory")]
+[assembly: InternalsVisibleTo("Simple.Data.Ado")]

--- a/Simple.Data/QueryPolyfills/ObjectMaths.cs
+++ b/Simple.Data/QueryPolyfills/ObjectMaths.cs
@@ -22,7 +22,7 @@ namespace Simple.Data.QueryPolyfills
             if (value is byte) return (byte)value + 1;
             if (value is sbyte) return (sbyte)value + 1;
 
-            throw new ArgumentException("Cannot increment object type.");
+            throw new ArgumentException(string.Format("Cannot increment object of type '{0}'.", value.GetType().FullName));
         }
 
         public static object Add(object value1, object value2)
@@ -43,11 +43,13 @@ namespace Simple.Data.QueryPolyfills
             if (value1 is byte) return (byte)value1 + (byte)value2;
             if (value1 is sbyte) return (sbyte)value1 + (sbyte)value2;
 
-            throw new ArgumentException("Cannot add object types.");
+            throw new ArgumentException(string.Format("Cannot add object of types '{0}' and '{1}'.", value1.GetType().FullName, value2.GetType().FullName));
         }
 
         public static object Divide(object value, int divisor)
         {
+            if (ReferenceEquals(value, null)) throw new ArgumentNullException("value");
+
             if (value is long) return (long)value / divisor;
             if (value is int) return (int)value / divisor;
             if (value is short) return (short)value / divisor;
@@ -60,7 +62,7 @@ namespace Simple.Data.QueryPolyfills
             if (value is byte) return (byte)value / divisor;
             if (value is sbyte) return (sbyte)value / divisor;
 
-            throw new ArgumentException("Cannot divide object type.");
+            throw new ArgumentException(string.Format("Cannot divide object of type '{0}'.", value.GetType()));
         }
     }
 }

--- a/Simple.Data/Simple.Data.csproj
+++ b/Simple.Data/Simple.Data.csproj
@@ -137,6 +137,7 @@
     <Compile Include="RunStrategy.cs" />
     <Compile Include="SelectClause.cs" />
     <Compile Include="SimpleDataConfigurationSection.cs" />
+    <Compile Include="SimpleDataTraceSources.cs" />
     <Compile Include="SimpleEmptyExpression.cs" />
     <Compile Include="SimpleFunction.cs" />
     <Compile Include="SimpleList.cs" />

--- a/Simple.Data/SimpleDataTraceSources.cs
+++ b/Simple.Data/SimpleDataTraceSources.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+
+namespace Simple.Data
+{
+    public static class SimpleDataTraceSources
+    {
+        private const string TraceSourceName = "Simple.Data";
+        private const SourceLevels DefaultLevel = SourceLevels.Warning;
+
+        // Verbose=1xxx Information=2xxx Warning=3xxx Error=4xxx Critical=5xxx
+        internal const int DebugMessageId = 1000;
+        internal const int SqlMessageId = 2000;
+        internal const int GenericWarningMessageId = 3000;
+        internal const int PerformanceWarningMessageId = 3001;
+        internal const int ObsoleteWarningMessageId = 3002;
+        internal const int GenericErrorMessageId = 4000;
+
+        private static TraceSource _traceSource;
+
+        public static TraceSource TraceSource
+        {
+            get { return _traceSource ?? (_traceSource = new TraceSource(TraceSourceName, DefaultLevel)); }
+        }
+    }
+}

--- a/Simple.Data/SimpleRecord.cs
+++ b/Simple.Data/SimpleRecord.cs
@@ -73,9 +73,9 @@ namespace Simple.Data
                         return true;
                     }
                 }
-                catch (UnresolvableObjectException)
+                catch (UnresolvableObjectException e)
                 {
-                    throw new UnresolvableObjectException("Column not found.");
+                    throw new UnresolvableObjectException(e.ObjectName, string.Format("Column '{0}' not found.", e.ObjectName));
                 }
             }
             return base.TryGetMember(binder, out result);

--- a/Simple.Data/SimpleRecord.cs
+++ b/Simple.Data/SimpleRecord.cs
@@ -75,7 +75,7 @@ namespace Simple.Data
                 }
                 catch (UnresolvableObjectException e)
                 {
-                    throw new UnresolvableObjectException(e.ObjectName, string.Format("Column '{0}' not found.", e.ObjectName));
+                    throw new UnresolvableObjectException(e.ObjectName, string.Format("Column '{0}' not found.", e.ObjectName), e);
                 }
             }
             return base.TryGetMember(binder, out result);

--- a/Simple.Data/SimpleTransaction.cs
+++ b/Simple.Data/SimpleTransaction.cs
@@ -127,7 +127,8 @@ namespace Simple.Data
             }
             catch (Exception ex)
             {
-                Trace.WriteLine("IAdapterTransaction Dispose threw exception: " + ex.Message);
+                SimpleDataTraceSources.TraceSource.TraceEvent(TraceEventType.Error, SimpleDataTraceSources.GenericErrorMessageId,
+                    "IAdapterTransaction Dispose threw exception: {0}", ex.Message);
             }
         }
 


### PR DESCRIPTION
- Changed logging with `Trace` to `TraceSource`. Log messages will now contain more information and it will be much easier to process and filter them. See #273 for more details.
- Changed all messages to include detailed information about unresolved objects, incorrect arguments etc. Receiving a message "Column not found" is not very helpful, especially in a library heavily relying on dynamic objects.
- Made sure exceptions are correctly rethrown. In some cases inner exceptions were not supplied to exception constructors which lead to cut off stack traces.
- Minor changes: added ReSharper settings file with your code conventions, fixed pluralization test (it failed if CurrentCulture is different from `en-us`).

On the whole, all changes are backwards compatible, with one exception: instead of attaching listeners to `Trace`, developers should now use `SimpleDataTraceSource.TraceSource`.

You should also review usages of `InvalidOperationException`. In some cases, `UnresolvableObjectException` and other specific classes should probably be used, but I didn't risk changing type to avoid exception handling compatibility.
