### PR TITLE
Solving problem when after using confuser assembly.FullName throws exception

### DIFF
--- a/Simple.Data/MefHelper.cs
+++ b/Simple.Data/MefHelper.cs
@@ -96,7 +96,14 @@ namespace Simple.Data
 
         private static bool IsSimpleDataAssembly(Assembly assembly)
         {
-            return assembly.GetFullName().StartsWith("Simple.Data.", StringComparison.OrdinalIgnoreCase);
+            try
+            {
+                return assembly.GetFullName().StartsWith("Simple.Data.", StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
I was using Confuser (http://confuser.codeplex.com/releases/view/90044) with my assembly. So after applying `assembly.GetFullName()` throws an exception. 
This simple commit resolve this problem 
