### PR TITLE
added support for dynamic indexer getter to SimpleRecord

### DIFF
--- a/Simple.Data.UnitTest/DynamicRecordTest.cs
+++ b/Simple.Data.UnitTest/DynamicRecordTest.cs
@@ -41,6 +41,17 @@ namespace Simple.Data.UnitTest
             Assert.AreEqual("Bob", target.Name);
         }
 
+        /// <summary>
+        ///A test for DynamicRecord Constructor
+        ///</summary>
+        [Test()]
+        public void DynamicRecordIndexerTest()
+        {
+            dynamic target = new SimpleRecord();
+            target.Name = "Bob";
+            Assert.AreEqual("Bob", target["Name"]);
+        }
+
         [Test]
         public void DynamicCastTest()
         {


### PR DESCRIPTION
I needed this in order to do string-based navigation of foreign-key relationships.
