### PR TITLE
Don't run update if new values equal original

### DIFF
--- a/Simple.Data.InMemoryTest/InMemoryTests.cs
+++ b/Simple.Data.InMemoryTest/InMemoryTests.cs
@@ -806,5 +806,21 @@
 
             Assert.AreEqual(3, actual.Count);
         }
+
+        [Test]
+        public void UpdateWithOriginalValuesRowsUpdatedShouldBeZeroIfNewValueAreSameAsOriginalValue()
+        {
+            var adapter = new InMemoryAdapter();
+            adapter.SetKeyColumn("Test", "Id");
+            Database.UseMockAdapter(adapter);
+            var db = Database.Open();
+            db.Test.Upsert(Id: 1, SomeValue: "Testing");
+            var record = db.Test.Get(1);
+            var record1 = record.Clone();
+
+            var rowsUpdated = db.Test.Update(record, record1);
+
+            Assert.AreEqual(0, rowsUpdated);
+        }
     }
 }

--- a/Simple.Data/DatabaseRunner.cs
+++ b/Simple.Data/DatabaseRunner.cs
@@ -44,6 +44,7 @@ namespace Simple.Data
         {
             SimpleExpression criteria = CreateCriteriaFromOriginalValues(tableName, newValuesDict, originalValuesDict);
             var changedValuesDict = CreateChangedValuesDict(newValuesDict, originalValuesDict);
+            if (changedValuesDict.Count == 0) return 0;
             return _adapter.Update(tableName, changedValuesDict, criteria);
         }
 

--- a/Simple.Data/TransactionRunner.cs
+++ b/Simple.Data/TransactionRunner.cs
@@ -96,6 +96,7 @@ namespace Simple.Data
         {
             SimpleExpression criteria = CreateCriteriaFromOriginalValues(tableName, newValuesDict, originalValuesDict);
             var changedValuesDict = CreateChangedValuesDict(newValuesDict, originalValuesDict);
+            if (changedValuesDict.Count == 0) return 0;
             return _adapter.Update(tableName, changedValuesDict, criteria, _adapterTransaction);
         }
 


### PR DESCRIPTION
When performing an update with optimistic concurrency, an update query is issued against the database even if the new values do not differ from the old values.  The syntax of the query that is generated is not well-formed (empty SET clause) so the update fails.

The implementations of _RunStrategy_ know whether the new value differs from the old value before performing the update.  If they do not differ, I propose that no update query is issued against the database and zero is returned for the number of records updated.
