### PR TITLE
Fixes issue #338. (SqlBulkInserter breaks when the records aren't homogenous)

### DIFF
--- a/Simple.Data.SqlTest/BulkInsertTest.cs
+++ b/Simple.Data.SqlTest/BulkInsertTest.cs
@@ -52,12 +52,94 @@ namespace Simple.Data.SqlTest
             Assert.AreEqual(1000, rowsWhichWhereUpdatedByTrigger);
         }
 
+
+        [Test]
+        public void BulkInsertRecordsWithDifferentColumnsProperlyInsertsData() 
+        {
+            DatabaseHelper.Reset();
+            
+            var db = DatabaseHelper.Open();
+            dynamic r1 = new SimpleRecord();
+            r1.FirstName = "Bob";
+            r1.LastName = "Dole";
+
+            dynamic r2 = new SimpleRecord();
+            r2.FirstName = "Bob";
+            r2.MiddleInitial = "L";
+            r2.LastName = "Saget";
+
+            db.OptionalColumnTest.Insert(new[] { r2, r1 });
+
+            var objs = db.OptionalColumnTest.All().ToList<OptionalColumnTestObject>();
+
+            var expected = new[] {new OptionalColumnTestObject("Bob", "Dole"), new OptionalColumnTestObject("Bob", "Saget", "L"),};
+
+            Assert.That(objs, Is.EquivalentTo(expected));
+
+        }
+
+        [Test]
+        public void BulkInsertRecordsWithDifferentColumnsAndFewerColumnsInFirstRecordProperlyInsertsData()
+        {
+            DatabaseHelper.Reset();
+
+            var db = DatabaseHelper.Open();
+
+            dynamic r1 = new SimpleRecord();
+            r1.FirstName = "Bob";
+            r1.LastName = "Dole";
+
+            dynamic r2 = new SimpleRecord();
+            r2.FirstName = "Bob";
+            r2.MiddleInitial = "L";
+            r2.LastName = "Saget";
+
+            db.OptionalColumnTest.Insert(new[] { r1, r2 });
+
+            var objs = db.OptionalColumnTest.All().ToList<OptionalColumnTestObject>();
+
+            var expected = new[] { new OptionalColumnTestObject("Bob", "Dole"), new OptionalColumnTestObject("Bob", "Saget", "L"), };
+
+            Assert.That(objs, Is.EquivalentTo(expected));
+
+        }
+
+
         private static IEnumerable<SchemaItem> GenerateItems()
         {
             for (int i = 0; i < 1000; i++)
             {
                 yield return new SchemaItem(i, i.ToString());
             }
+        }
+    }
+
+    class OptionalColumnTestObject
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string MiddleInitial { get; set; }
+
+        public OptionalColumnTestObject() {}
+
+        public OptionalColumnTestObject(string first, string last, string middle = null) 
+        {
+            FirstName = first;
+            LastName = last;
+            MiddleInitial = middle;
+        }
+
+        public override string ToString() 
+        {
+            return string.Format("<FirstName={0}, LastName={1}, MiddleInitial={2}>", FirstName, LastName, MiddleInitial);
+        }
+
+        public override bool Equals(object obj) 
+        {
+            var other = obj as OptionalColumnTestObject;
+            if (other == null) return false;
+            return other.FirstName == FirstName && other.LastName == LastName && other.MiddleInitial == MiddleInitial;
         }
     }
 

--- a/Simple.Data.SqlTest/Resources/DatabaseReset.txt
+++ b/Simple.Data.SqlTest/Resources/DatabaseReset.txt
@@ -86,6 +86,8 @@ BEGIN
 	DROP TABLE [dbo].[HierarchyIdTest]
 	IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[TimestampTest]') AND type in (N'U'))
 	DROP TABLE [dbo].[TimestampTest]
+	IF EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[OptionalColumnTest]') AND type in (N'U'))
+	DROP TABLE [dbo].[OptionalColumnTest]
 
 	CREATE TABLE [dbo].[Users] (
 		[Id]       INT            IDENTITY (1, 1) NOT NULL,
@@ -244,6 +246,16 @@ BEGIN
 	(
 		[Id] ASC
 	))
+
+	CREATE TABLE [dbo].[OptionalColumnTest](
+		[Id] [int] IDENTITY(1,1) NOT NULL,
+		[FirstName] [nvarchar](50),
+		[LastName] [nvarchar](50),
+		[MiddleInitial] [nvarchar](50),
+	)
+
+	ALTER TABLE [dbo].[OptionalColumnTest]
+		ADD CONSTRAINT [PK_OptionalColumnTest] PRIMARY KEY CLUSTERED ([Id] ASC)
 
 	BEGIN TRANSACTION
 	SET IDENTITY_INSERT [dbo].[Customers] ON


### PR DESCRIPTION
I've also added a couple tests for this, but I had to end up added a table specifically for these tests because none of the existing tables had enough optional columns.  I also didn't realize until a bit late that the db isn't reset before each test only before each set of tests so I added `DatabaseHelper.Reset()` to those two tests.  If you'd prefer the tests formatted in a different way, just let me know.

Thanks,

Matt
