### PR TITLE
Fix stored proc resolution for non-dbo schema

### DIFF
--- a/Simple.Data.Ado/Schema/ProcedureCollection.cs
+++ b/Simple.Data.Ado/Schema/ProcedureCollection.cs
@@ -61,7 +61,21 @@ namespace Simple.Data.Ado.Schema
             }
             if (!string.IsNullOrWhiteSpace(_defaultSchema))
             {
-                return Find(procedureName, _defaultSchema);
+                try
+                {
+                    return Find(procedureName, _defaultSchema);
+                } 
+                catch (UnresolvableObjectException)
+                {
+                    var procedure = FindprocedureWithName(procedureName.Homogenize())
+                                    ?? FindprocedureWithPluralName(procedureName.Homogenize())
+                                    ?? FindprocedureWithSingularName(procedureName.Homogenize());
+
+                    if (procedure == null)
+                    {
+                        throw;
+                    }
+                }
             }
             return FindprocedureWithName(procedureName.Homogenize())
                    ?? FindprocedureWithPluralName(procedureName.Homogenize())


### PR DESCRIPTION
I was actually facing trouble to properly use stored proc. In a transaction, I found out that the active transaction is not assigned to the stored proc SqlCommand object if I explicitly specify the schema of the stored proc.

The active transaction will be properly assigned if I did not explicitly specify the schema, however this will only work when the schema of the stored proc is dbo.

The options I had, sorted by most preferred to least preferred:
1. Properly assign the active transaction when the schema is explicitly stated - did not figure out how to do this
2. Stored proc lookup should work across all schema when no schema is specified - included in this pull request
3. Change the schema of my stored proc to dbo - pretty much unacceptable
