### PR TITLE
Fix InMemoryAdapter queries after deleting from a join table

### DIFF
--- a/Simple.Data.Ado.Test/ProviderHelperTest.cs
+++ b/Simple.Data.Ado.Test/ProviderHelperTest.cs
@@ -90,6 +90,16 @@ namespace Simple.Data.Ado.Test
                 throw new NotImplementedException();
             }
 
+            public void SetSharedConnection(object sharedConnection)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool IsSharedConnection()
+            {
+                return false;
+            }
+
             public Type RequestedServiceType { get; private set; }
             public Object GetService(Type serviceType)
             {

--- a/Simple.Data.Ado.Test/TestCustomInserter.cs
+++ b/Simple.Data.Ado.Test/TestCustomInserter.cs
@@ -64,6 +64,16 @@ namespace Simple.Data.Ado.Test
         {
             throw new NotImplementedException();
         }
+
+        public void SetSharedConnection(object sharedConnection)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSharedConnection()
+        {
+            return false;
+        }
     }
 
     public class StubSchemaProvider : ISchemaProvider

--- a/Simple.Data.Ado/AdoAdapter.cs
+++ b/Simple.Data.Ado/AdoAdapter.cs
@@ -318,6 +318,7 @@ namespace Simple.Data.Ado
         public void UseSharedConnection(IDbConnection connection)
         {
             _sharedConnection = connection;
+            _connectionProvider.SetSharedConnection(connection);
         }
 
         public void StopUsingSharedConnection()

--- a/Simple.Data.Ado/IConnectionProvider.cs
+++ b/Simple.Data.Ado/IConnectionProvider.cs
@@ -14,5 +14,7 @@ namespace Simple.Data.Ado
         string GetIdentityFunction();
         bool SupportsStoredProcedures { get; }
         IProcedureExecutor GetProcedureExecutor(AdoAdapter adapter, ObjectName procedureName);
+        void SetSharedConnection(object sharedConnection);
+        bool IsSharedConnection();
     }
 }

--- a/Simple.Data.Mocking/Ado/MockConnectionProvider.cs
+++ b/Simple.Data.Mocking/Ado/MockConnectionProvider.cs
@@ -74,6 +74,16 @@ namespace Simple.Data.Mocking.Ado
             return new ProcedureExecutor(adapter, procedureName);
         }
 
+        public void SetSharedConnection(object sharedConnection)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSharedConnection()
+        {
+            return false;
+        }
+
         private bool _supportsCompoundStatements = true;
         public bool SupportsCompoundStatements
         {

--- a/Simple.Data.SqlCe40/SqlCe40ConnectionProvider.cs
+++ b/Simple.Data.SqlCe40/SqlCe40ConnectionProvider.cs
@@ -74,5 +74,15 @@ namespace Simple.Data.SqlCe40
         {
             throw new NotSupportedException("SQL Server Compact Edition does not support stored procedures.");
         }
+
+        public void SetSharedConnection(object sharedConnection)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsSharedConnection()
+        {
+            return false;
+        }
     }
 }

--- a/Simple.Data.SqlServer/SqlConnectionProvider.cs
+++ b/Simple.Data.SqlServer/SqlConnectionProvider.cs
@@ -14,6 +14,7 @@ namespace Simple.Data.SqlServer
     public class SqlConnectionProvider : IConnectionProvider
     {
         private string _connectionString;
+        private SqlConnection _sharedConnection;
 
         public SqlConnectionProvider()
         {
@@ -27,7 +28,7 @@ namespace Simple.Data.SqlServer
 
         public IDbConnection CreateConnection()
         {
-            return new SqlConnection(_connectionString);
+            return _sharedConnection ?? new SqlConnection(_connectionString);
         }
 
         public ISchemaProvider GetSchemaProvider()
@@ -78,6 +79,16 @@ namespace Simple.Data.SqlServer
         public IProcedureExecutor GetProcedureExecutor(AdoAdapter adapter, ObjectName procedureName)
         {
             return new ProcedureExecutor(adapter, procedureName);
+        }
+
+        public void SetSharedConnection(object sharedConnection)
+        {
+            _sharedConnection = (SqlConnection) sharedConnection;
+        }
+
+        public bool IsSharedConnection()
+        {
+            return _sharedConnection != null;
         }
     }
 }


### PR DESCRIPTION
Fix the InMemoryAdapter so it properly cleans up the Detail/Master records on delete.
Added a test for the scenario.
