### PR TITLE
The distinct clause does not works with InMemoryAdapter

### DIFF
--- a/Simple.Data.InMemoryTest/InMemoryTests.cs
+++ b/Simple.Data.InMemoryTest/InMemoryTests.cs
@@ -188,6 +188,16 @@
             Assert.AreEqual("Bob", records[0].Name);
         }
 
+        [Test]
+        public void SelectWithDistinctShouldReturnOnlyDistinctRows()
+        {
+            var db = CreateAggregateTestDb();
+            var records = db.Test.All().Select(db.Test.Name).Distinct().ToList();
+            Assert.AreEqual(2, records.Count);
+            Assert.AreEqual("Alice", records[0].Name);
+            Assert.AreEqual("Bob", records[1].Name);
+        }
+
         private static dynamic CreateAggregateTestDb()
         {
             Database.UseMockAdapter(new InMemoryAdapter());

--- a/Simple.Data/QueryPolyfills/DictionaryQueryRunner.cs
+++ b/Simple.Data/QueryPolyfills/DictionaryQueryRunner.cs
@@ -47,6 +47,9 @@ namespace Simple.Data.QueryPolyfills
             }
 
             source = RunOrderByClauses(source);
+            
+            source = RunHavingClauses(source);
+            source = RunSelectClauses(source);
 
             foreach (var clause in _clauses)
             {
@@ -56,9 +59,7 @@ namespace Simple.Data.QueryPolyfills
                     source = handler(clause, source);
                 }
             }
-            
-            source = RunHavingClauses(source);
-            source = RunSelectClauses(source);
+
             return source;
         }
 


### PR DESCRIPTION
When you add a .Distinct() clause to a SimpleQuery like

var records = db.Test.All().Select(db.Test.Name).Distinct().ToList();

It simply has no effect.
