### PR TITLE
Demonstrate effect of position in query of 'Select' clause for 'Get'

### DIFF
--- a/Simple.Data.SqlTest/GetTests.cs
+++ b/Simple.Data.SqlTest/GetTests.cs
@@ -31,6 +31,27 @@ namespace Simple.Data.SqlTest
         }
 
         [Test]
+        public void GetWithSelectClauseShouldRestrictColumn()
+        {
+            var db = DatabaseHelper.Open();
+           
+            var actual = db.Users.Select(db.Users.Name, db.Users.Age).Get(1);
+            
+            Assert.AreEqual("Bob", actual.Name);
+            Assert.AreEqual(32, actual.Age);
+            Assert.Throws<UnresolvableObjectException>(() => Console.WriteLine(actual.Id), "Column 'Id' not found.");
+            Assert.Throws<UnresolvableObjectException>(() => Console.WriteLine(actual.Password), "Column 'Password' not found.");
+        }
+
+        [Test]
+        public void GetWithMisplacedSelectClauseThrowsException()
+        {
+            var db = DatabaseHelper.Open();
+            Assert.Throws<UnresolvableObjectException>(
+                        () => db.Users.Get(1).Select(db.Users.Name, db.Users.Age));
+        }
+
+        [Test]
         public void SelectClauseWithGetScalarShouldLimitQuery()
         {
             var db = DatabaseHelper.Open();


### PR DESCRIPTION
I found some inconsistent behaviour with Select clauses on 'Get' queries, so I wrote a couple of tests that demonstrate it.  I know you're working on v2 (did you get your X-Box?) so I'm not sure if this is of any interest to you.  

If you do merge the changes in, I'll reference these tests when I make a pull request on http://simplefx.org/simpledata/docs/ updating the detail on 'Select' with regards to 'Get's.

Cheers,
Steve
