### PR TITLE
Test for transaction rollback on procedure with specified schema

### DIFF
--- a/Simple.Data.SqlTest/TransactionTests.cs
+++ b/Simple.Data.SqlTest/TransactionTests.cs
@@ -55,6 +55,27 @@ namespace Simple.Data.SqlTest
             Assert.AreEqual(1, db.OrderItems.All().ToList().Count);
         }
 
+        [Test, Ignore("TODO: fix transactions?")]
+        public void TestRollbackOnProcedureWithSpecifiedSchema()
+        {
+            var db = DatabaseHelper.Open();
+
+            int customerId;
+            using (var tx = db.BeginTransaction())
+            {
+                var customer = tx.dbo.CreateCustomer().FirstOrDefault();
+                customerId = customer.CustomerId;
+                
+                var customerBeforeRollback = db.Customers.FindByCustomerId(customerId);
+                Assert.IsNotNull(customerBeforeRollback);
+                
+                tx.Rollback();
+            }
+
+            var customerAfterRollback = db.Customers.FindByCustomerId(customerId);
+            Assert.IsNull(customerAfterRollback);
+        }
+        
         [Test]
         public void TestWithOptionsTransaction()
         {


### PR DESCRIPTION
Hi,

We are experiencing an issue with rolling back a transaction which executes a stored procedure in a schema other than dbo.  I have created a test that reproduces the issue: even if the schema is dbo, by specifying it explicitly we lose the transaction.

I followed the code through as far as DynamicSchema.TryInvokeMember calling command.Execute without passing any transaction?  That's as far as I got, but I could be going down completely the wrong rabbit hole...  I'd be happy to (try to) help further if you agree this is in need of fixing!

Tim
