### PR TITLE
check bounds rather than generate exceptions

### DIFF
--- a/Simple.Data.Ado/OptimizedDictionary2.cs
+++ b/Simple.Data.Ado/OptimizedDictionary2.cs
@@ -209,7 +209,8 @@ namespace Simple.Data.Ado
                 // Rethrow exceptions from here to hide implementation details.
                 try
                 {
-                    return _values[_index[key]];
+                    var ordinal = _index[key];
+                    return ordinal < _values.Count ? _values[ordinal] : default(TValue);
                 }
                 catch (ArgumentNullException)
                 {
@@ -218,10 +219,6 @@ namespace Simple.Data.Ado
                 catch (KeyNotFoundException)
                 {
                     throw new KeyNotFoundException();
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    return default(TValue);
                 }
             }
             set


### PR DESCRIPTION
This had a serious performance benefit. In my case (single select fetching 164 records) the catch block for ArgumentOutOfRangeException was hit 432 times. Using an explicit bounds check prevented these exceptions and was noticeably faster
