### PR TITLE
Make the SimpleDataExceptionTest.EmptyConstructor test pass

### DIFF
--- a/Simple.Data.UnitTest/SimpleDataExceptionTest.cs
+++ b/Simple.Data.UnitTest/SimpleDataExceptionTest.cs
@@ -7,6 +7,7 @@
     public class SimpleDataExceptionTest
     {
         [Test]
+        [SetUICulture("en-US")]
         public void EmptyConstructor()
         {
             var actual = new SimpleDataException();


### PR DESCRIPTION
Make the `SimpleDataExceptionTest.EmptyConstructor` test pass even if the
current culture is non-English.
