### PR TITLE
Modified method ToOrderByDirective to use given db schema instead of default.

### DIFF
--- a/Simple.Data.Ado/QueryBuilderBase.cs
+++ b/Simple.Data.Ado/QueryBuilderBase.cs
@@ -314,7 +314,7 @@ namespace Simple.Data.Ado
             }
             else
             {
-                var table = _schema.FindTable(item.Reference.GetOwner().GetName());
+                var table = _schema.FindTable(item.Reference.GetOwner().ToString());
                 name = table.FindColumn(item.Reference.GetName()).QualifiedName;
             }
 


### PR DESCRIPTION
When we have database with 2 tables like: ProcesAndOperation.Processes, dbo.Processes and we want take records from ProcesAndOperation.Processes, with order by ProcesAndOperation.Processes.Id desc, we will catch error. It will be caused by the sql query "select ProcesAndOperation.Processes.Id, ProcesAndOperation.Processes.Comments from ProcesAndOperation.Processes order by dbo.Processes.Id desc". Problem is in method GetName() - it takes only table name Processes without database schema. This fix is working for me.